### PR TITLE
security(compose): enable read_only root FS for litellm

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,11 @@ services:
     memswap_limit: ${LITELLM_MEMSWAP_LIMIT:-1g}
     cpus: ${LITELLM_CPUS:-1.0}
     pids_limit: ${LITELLM_PIDS_LIMIT:-256}
+    # ルート FS を read-only 化し、runtime 改ざん面を削減。
+    # Python プロセスが必要とする書き込み先（一時ファイル等）は tmpfs で提供する。
+    read_only: true
+    tmpfs:
+      - /tmp:size=128m,mode=1777
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:4000/health/liveliness')"]
       interval: 10s


### PR DESCRIPTION
## Summary

`litellm` サービスに `read_only: true` を付与し、ルート FS への runtime 書き込みを構造的に封じる。書き込み要件がある `/tmp` のみ tmpfs (128m) で提供。

Read-only root FS 段階導入の第 1 弾（litellm 先行）。次段階で `dev` サービスにも展開予定。

## 検証結果（実環境）

```
$ docker compose up -d --force-recreate litellm
$ docker compose ps litellm
NAME                   STATUS
cldev-book-litellm-1   Up (healthy)

$ docker compose exec litellm python -c "import urllib.request; print(urllib.request.urlopen('http://localhost:4000/health/liveliness').status)"
200

$ docker compose exec litellm touch /etc/foo
touch: /etc/foo: Read-only file system
```

- healthcheck 通過（API プロキシ機能維持）
- `/health/liveliness` 200 応答
- `/etc/foo` への書き込みが read-only で拒否

## セキュリティ効果

- runtime に悪意コードをディスクへ常駐させる攻撃（`/usr/bin/*` 上書き、`.bashrc` 改ざん等）を封じる
- LiteLLM プロセス侵害時のラテラルムーブメントに対する防御層を追加

## 既知の警告（無害）

LiteLLM 起動ログに以下の WARNING が出る:

```
Cannot restructure UI at /usr/lib/python3.13/site-packages/litellm/proxy/_experimental/out: path is not writable. UI may not work correctly for extensionless routes.
```

これは admin UI の extensionless route 用の再構築処理で、API プロキシ用途（Claude Code 経由の LLM 呼び出し）には影響しない。UI を利用する場合は Dockerfile で build-time に再構築する対応が必要。

## Test plan

- [x] \`docker compose config --quiet\` 成功
- [x] \`docker compose up -d --force-recreate litellm\` で起動
- [x] \`Up (healthy)\` 確認
- [x] \`/health/liveliness\` 200 応答
- [x] \`touch /etc/foo\` が read-only で拒否

## Next

- [ ] 同じ対応を \`dev\` サービスに展開（書き込み経路が多いため別 PR）

🤖 Generated with [Claude Code](https://claude.com/claude-code)