### PR TITLE
security(compose): pin docker-socket-proxy image + doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,7 +579,13 @@ cd my-project
 
 ### Docker-in-Docker
 
-dev コンテナからホストの Docker ソケットがマウントされているため、コンテナ内で `docker` / `docker compose` コマンドが利用可能。workspace 内のプロジェクトが独自の `docker-compose.yml` を持つ場合、コンテナ内から直接起動できる。
+dev コンテナ内で `docker` / `docker compose` コマンドが利用可能。workspace 内のプロジェクトが独自の `docker-compose.yml` を持つ場合、コンテナ内から直接起動できる。
+
+**仕組み**: `/var/run/docker.sock` を直接マウントする代わりに、`tecnativa/docker-socket-proxy` を経由してホストの Docker API にアクセスする (`DOCKER_HOST=tcp://docker-proxy:2375`)。proxy は必要最小限の API のみを許可し、コンテナエスケープの王道経路（`docker run --privileged -v /:/host ...` 等）を構造的に遮断する。
+
+**許可されている API** (dev の用途で必要なもの): `CONTAINERS` / `IMAGES` / `NETWORKS` / `VOLUMES` / `SERVICES` / `TASKS` / `EXEC` / `BUILD` / `INFO` / `PING` / `VERSION` / `POST`
+
+**無効化されている API**: `AUTH` / `SECRETS` / `SWARM` / `SYSTEM`(prune) / `CONFIGS` / `PLUGINS` / `NODES` / `DISTRIBUTION`
 
 ## サプライチェーン攻撃対策
 

--- a/SECURITY-GUIDE.md
+++ b/SECURITY-GUIDE.md
@@ -92,11 +92,18 @@ Claude Codeは強力なツールだが、ファイル操作・コマンド実行
 | ~/.aws/credentials の読み取り | コンテナ内に存在しない |
 | 他のリポジトリへのアクセス | /workspace のみマウント |
 | ホストのプロセスへの影響 | コンテナのプロセス空間は隔離 |
+| **Docker API 経由のコンテナエスケープ** | **docker-socket-proxy で API 粒度を制限**（下記参照） |
 
 **ポイント**:
 - Claude Codeがどんなコマンドを実行しても、ホストPCには影響しない
 - これが「最終的な安全ネット」として機能する
 - APIキー（`.env`）はコンテナ内にのみ存在し、ホスト環境から分離
+
+**Docker Socket Proxy**: dev コンテナから `docker` / `docker compose` を使用する際、`/var/run/docker.sock` を直接マウントする代わりに `tecnativa/docker-socket-proxy` を経由する。直接マウントは `docker run --privileged -v /:/host ...` 等で **ホスト root 掌握可能** な王道経路となるため、proxy で許可 API を最小化して遮断する。
+
+- 許可: `CONTAINERS` / `IMAGES` / `NETWORKS` / `VOLUMES` / `SERVICES` / `TASKS` / `EXEC` / `BUILD` / `INFO` / `PING` / `VERSION` / `POST`
+- 無効: `AUTH` / `SECRETS` / `SWARM` / `SYSTEM`(prune) / `CONFIGS` / `PLUGINS` / `NODES` / `DISTRIBUTION`
+- proxy 自身も `read_only: true` + リソース制限で強化、socket は `:ro` で接続
 
 ### 第2層: ファイアウォール（通信制御）
 

--- a/docker-compose-without-litellm.yml
+++ b/docker-compose-without-litellm.yml
@@ -3,7 +3,8 @@ services:
   # tecnativa/docker-socket-proxy を介して必要最小限の API だけを公開する。
   # 詳細は docker-compose.yml の同名サービス参照。
   docker-proxy:
-    image: tecnativa/docker-socket-proxy:v0.4.2
+    # SHA256 digest で pin（詳細は docker-compose.yml の同名サービス参照）
+    image: tecnativa/docker-socket-proxy:v0.4.2@sha256:1f3a6f303320723d199d2316a3e82b2e2685d86c275d5e3deeaf182573b47476
     restart: unless-stopped
     read_only: true
     tmpfs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,11 @@ services:
   # 直接マウントはコンテナエスケープの王道経路（--privileged で任意コンテナ起動可）
   # のため、許可 API を絞った経路に置き換えてホスト root 掌握リスクを縮小する。
   docker-proxy:
-    # TODO: 初回 pull 後に SHA256 digest で pin する（litellm と同様のサプライチェーン対策）
-    # docker pull tecnativa/docker-socket-proxy:0.4.2 && \
-    #   docker inspect --format='{{index .RepoDigests 0}}' tecnativa/docker-socket-proxy:0.3.0
-    image: tecnativa/docker-socket-proxy:v0.4.2
+    # SHA256 digest で pin（litellm と同様のサプライチェーン対策）
+    # 更新手順:
+    #   docker pull tecnativa/docker-socket-proxy:v0.4.2 && \
+    #     docker inspect --format='{{index .RepoDigests 0}}' tecnativa/docker-socket-proxy:v0.4.2
+    image: tecnativa/docker-socket-proxy:v0.4.2@sha256:1f3a6f303320723d199d2316a3e82b2e2685d86c275d5e3deeaf182573b47476
     restart: unless-stopped
     read_only: true
     tmpfs:


### PR DESCRIPTION
## Summary

前 PR #25 で導入した `tecnativa/docker-socket-proxy` について、サプライチェーン対策の一貫性確保とドキュメント整備を行う。

## 変更点

### image SHA256 digest pin

```diff
- image: tecnativa/docker-socket-proxy:v0.4.2
+ image: tecnativa/docker-socket-proxy:v0.4.2@sha256:1f3a6f303320723d199d2316a3e82b2e2685d86c275d5e3deeaf182573b47476
```

`litellm` と同様の SHA256 digest pin を適用。tag 移動による不意のイメージ差し替えを防ぐ。

更新手順コメントも compose 内に記載済み。

### README.md

`Docker-in-Docker` 章を docker-proxy 経由である事実に合わせて書き直し:
- 直接 socket マウント撤廃の旨
- 許可 API / 無効 API の列挙
- コンテナエスケープ遮断の意図

### SECURITY-GUIDE.md

第 1 層（DevContainer 物理隔離）の脅威表に「Docker API 経由のコンテナエスケープ」行を追加し、docker-socket-proxy の仕組み説明を別段落で追加。

## 検証

- `docker compose config --quiet` 両 compose ファイルで成功
- `docker compose up -d --force-recreate docker-proxy` で起動確認
- `docker compose ps` で image 名に `@sha256:...` が表示されることを確認
- dev 経由の `docker version` で Server 応答維持を確認

## Test plan

- [x] compose syntax validation
- [x] proxy 再作成で Up 状態を維持
- [x] SHA pin 適用後も Docker API 到達性維持
- [x] README / SECURITY-GUIDE の記載が現実装と一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)
