### PR TITLE
security(claude-settings): project パス差し替え + 権限/サンドボックス絞り込み

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-
   "permissions": {
     "allow": [
       "Read",
@@ -19,7 +18,18 @@
       "Bash(pip *)",
       "Bash(gradle *)",
       "Bash(mvn *)",
-      "Bash(gh *)",
+      "Bash(gh pr *)",
+      "Bash(gh issue *)",
+      "Bash(gh repo view *)",
+      "Bash(gh repo list *)",
+      "Bash(gh repo clone *)",
+      "Bash(gh run *)",
+      "Bash(gh release view *)",
+      "Bash(gh release list *)",
+      "Bash(gh auth status)",
+      "Bash(gh label *)",
+      "Bash(gh search *)",
+      "Bash(gh browse *)",
       "Bash(make *)",
       "Bash(docker compose *)",
       "Bash(ls *)",
@@ -35,7 +45,6 @@
       "Bash(cp *)",
       "Bash(mv *)",
       "Bash(touch *)",
-      "Bash(chmod *)",
       "Bash(echo *)",
       "Bash(cd *)",
       "Bash(pwd)",
@@ -66,6 +75,18 @@
       "Bash(* sed -i * settings.json*)",
       "Bash(* sed -i * .claude.json*)",
       "Bash(* sed -i * .mcp.json*)",
+      "Bash(gh api *)",
+      "Bash(gh auth token*)",
+      "Bash(gh auth login*)",
+      "Bash(gh auth logout*)",
+      "Bash(gh auth refresh*)",
+      "Bash(gh secret *)",
+      "Bash(gh variable *)",
+      "Bash(gh workflow run*)",
+      "Bash(gh workflow enable*)",
+      "Bash(gh workflow disable*)",
+      "Bash(gh ssh-key *)",
+      "Bash(gh gpg-key *)",
       "Bash(curl *)",
       "Bash(wget *)",
       "Bash(ssh *)",
@@ -76,6 +97,15 @@
       "Bash(ftp *)",
       "Bash(sudo *)",
       "Bash(chmod 777 *)",
+      "Bash(chmod 666 *)",
+      "Bash(chmod -R 777 *)",
+      "Bash(chmod -R 666 *)",
+      "Bash(chmod u+s *)",
+      "Bash(chmod g+s *)",
+      "Bash(chmod +s *)",
+      "Bash(chmod 4* *)",
+      "Bash(chmod 2* *)",
+      "Bash(chmod 6* *)",
       "Bash(eval *)",
       "Bash(exec *)",
       "Bash(nohup *)",
@@ -88,6 +118,12 @@
       "Write(.env.*)",
       "Edit(.env)",
       "Edit(.env.*)",
+      "Write(.claude/hooks/**)",
+      "Edit(.claude/hooks/**)",
+      "Write(.claude/settings.json)",
+      "Edit(.claude/settings.json)",
+      "Write(.claude/settings.local.json)",
+      "Edit(.claude/settings.local.json)",
       "Read(~/.ssh/**)",
       "Read(~/.aws/**)",
       "Read(~/.gnupg/**)",
@@ -108,7 +144,7 @@
     ],
     "filesystem": {
       "allowWrite": [
-        "/Users/tsuchitakouji/pg_work_space/mra_chat_01/claude-dev-env/workspace",
+        "/Users/tsuchitakouji/pg_work_space/claude_test/cldev-book/workspace",
         "~/.npm",
         "~/.cache",
         "~/.local",
@@ -117,8 +153,10 @@
         "/tmp"
       ],
       "denyWrite": [
-        "/Users/tsuchitakouji/pg_work_space/mra_chat_01/claude-dev-env/.claude/settings.json",
-        "/Users/tsuchitakouji/pg_work_space/mra_chat_01/claude-dev-env/.claude/settings.local.json",
+        "/Users/tsuchitakouji/pg_work_space/claude_test/cldev-book/.claude/settings.json",
+        "/Users/tsuchitakouji/pg_work_space/claude_test/cldev-book/.claude/settings.local.json",
+        "/Users/tsuchitakouji/pg_work_space/claude_test/cldev-book/.claude/hooks",
+        "/Users/tsuchitakouji/pg_work_space/claude_test/cldev-book/.claude/skills",
         "/etc"
       ],
       "denyRead": [
@@ -153,7 +191,7 @@
         "us.cloud.langfuse.com"
       ],
       "allowLocalBinding": true,
-      "allowAllUnixSockets": true
+      "allowAllUnixSockets": false
     }
   },
 
@@ -240,6 +278,6 @@
 
   "env": {
     "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
-    "PIP_CONFIG_FILE": "/Users/tsuchitakouji/pg_work_space/mra_chat_01/claude-dev-env/workspace/.pip.conf"
+    "PIP_CONFIG_FILE": "/Users/tsuchitakouji/pg_work_space/claude_test/cldev-book/workspace/.pip.conf"
   }
 }


### PR DESCRIPTION
## Summary

`.claude/settings.json` のセキュリティ観点レビューで判明した項目を修正。High × 1、Medium × 2、Low × 3 をまとめて対応。

## 変更点

### 🔴 High: mra_chat_01 参照を cldev-book 配下に差し替え

本プロジェクト (`cldev-book`) と無関係の別プロジェクト配下のパスが参照されていた残留設定を修正:

- `sandbox.filesystem.allowWrite` — `mra_chat_01/.../workspace` → `cldev-book/workspace`
- `sandbox.filesystem.denyWrite` — `mra_chat_01/.../settings*.json` → `cldev-book/.claude/settings*.json`
- `env.PIP_CONFIG_FILE` — `mra_chat_01/.../.pip.conf` → `cldev-book/workspace/.pip.conf`

PIP_CONFIG_FILE は別プロジェクトで `index-url` が差し替えられると本プロジェクトの `pip install` が誘導されるため、実質的なサプライチェーンリスクがあった。

### 🟠 Medium: `gh` サブコマンドの絞り込み

- `Bash(gh *)` allow を削除し、`gh pr/issue/repo view/repo list/repo clone/run/release view/release list/label/search/browse/auth status` に限定
- deny に `gh api`, `gh auth token/login/logout/refresh`, `gh secret`, `gh variable`, `gh workflow run/enable/disable`, `gh ssh-key`, `gh gpg-key` を追加

`gh api` による任意 HTTP、`gh auth token` によるトークン漏洩、`gh workflow run` による CI トリガーなどを遮断。

### 🟡 Low: `chmod` allow 削除 + 危険モード deny 列挙

- `Bash(chmod *)` allow を削除（setuid/setgid/world-writable も通っていた）
- deny に `chmod 666`, `chmod -R 777/666`, `chmod u+s/g+s/+s`, `chmod 4*/2*/6* *`（setuid/setgid 数値指定）を追加

### 🟡 Low: hook スクリプトの保護

- `sandbox.filesystem.denyWrite` に `.claude/hooks` と `.claude/skills` を追加
- `permissions.deny` に `Write(.claude/hooks/**)`, `Edit(.claude/hooks/**)`, `Write/Edit(.claude/settings.json)`, `Write/Edit(.claude/settings.local.json)` を追加

`echo ... > .claude/hooks/*.sh` 等で PreToolUse フックを骨抜きにされる経路を塞ぐ。

### 🟡 Low: `allowAllUnixSockets` を false

- `sandbox.network.allowAllUnixSockets` を `true` → `false`

現 compose は docker-proxy TCP 経由 (`tcp://docker-proxy:2375`) なので影響なし。将来 `/var/run/docker.sock` が誤マウントされた際の素通しを防止。

## 方針メモ

Bash allow/deny は `python -c "import urllib; ..."` や `node -e "require('https').request(...)"` で回避可能なため、**ネットワーク egress 制御は firewall が主防御**（dev container 側 `init-firewall.sh` で実装済）。本 PR の Bash 制限は hardening 補助。

## 検証

- `jq empty .claude/settings.json` — JSON 構文 OK
- `git diff` で差分意図通り（1 file, +46 −8）
- 既存 WIP（`.devcontainer/init-firewall.sh`, `workspace/.claude/settings.json`, `workspace/.pip.conf`）は本コミットに含まれていないことを確認

## Test plan

- [x] JSON 構文検証
- [x] 差分が意図通り
- [ ] マージ後、Claude Code 再起動で新 settings.json が読み込まれること
- [ ] `gh api` が実際に拒否されること（spot check）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
