### PR TITLE
security(hook): block-dangerous.sh に gh 危険サブコマンド + chmod setuid/setgid 検出を追加

### DIFF
--- a/.claude/hooks/block-dangerous.sh
+++ b/.claude/hooks/block-dangerous.sh
@@ -70,9 +70,22 @@ if echo "$COMMAND" | grep -qE '(printenv|env)\s*\|.*(curl|wget|nc|python|node)';
   exit 2
 fi
 
-# chmod 777 (overly permissive)
-if echo "$COMMAND" | grep -qE 'chmod\s+777'; then
-  echo '{"decision": "block", "reason": "Blocked: chmod 777 is not allowed"}' >&2
+# gh CLI の危険サブコマンド
+# - gh api: 認証済みトークンによる任意 HTTP（repo 横断書込の濫用経路）
+# - gh auth token: トークン平文出力（ログ・他プロセスへの漏洩）
+# - gh auth login/logout/refresh: 認証状態の操作
+# - gh secret / variable: repo secret/variable の読取・変更
+# - gh workflow run/enable/disable: CI 任意起動・状態変更（CI 経由 RCE）
+# - gh ssh-key / gpg-key: 永続化鍵の追加
+if echo "$COMMAND" | grep -qE '\bgh\s+(api|secret|variable|ssh-key|gpg-key)\b|\bgh\s+auth\s+(token|login|logout|refresh)\b|\bgh\s+workflow\s+(run|enable|disable)\b'; then
+  echo '{"decision": "block", "reason": "Blocked: dangerous gh subcommand (api / auth token / secret / variable / workflow run / ssh-key / gpg-key)"}' >&2
+  exit 2
+fi
+
+# chmod: world-writable / setuid (u+s, 4xxx) / setgid (g+s, 2xxx) / sticky+SUID+SGID (6xxx) / -R 再帰
+# シンボリック (+s) も数値 (4755 等) も両対応。setuid バイナリ作成は権限昇格の直接経路
+if echo "$COMMAND" | grep -qE 'chmod\s+([ug]?\+s|777|666|-R\s+(777|666)|[2467][0-7]{3})(\s|$)'; then
+  echo '{"decision": "block", "reason": "Blocked: chmod with overly permissive or setuid/setgid mode is not allowed"}' >&2
   exit 2
 fi
 


### PR DESCRIPTION
## Summary

PR #27 で `.claude/settings.json` deny に追加した `gh` 危険サブコマンドと `chmod` setuid/setgid 系を、`.claude/hooks/block-dangerous.sh` にも反映して多層防御化する。

settings.json の deny ルールはパターンマッチベースのため、以下の経路で容易に回避可能:

- サブシェル / `bash -c "..."`
- コマンドチェイン (`X && Y`)
- パイプ経由の echo → sh
- 引用符・エスケープのバリエーション

hook は command 全文を regex で走査するため、これらの回避経路を横断して検出できる。

## 追加した検出

### gh CLI 危険サブコマンド

| サブコマンド | 実害 |
|---|---|
| `gh api` | 認証済みトークンで任意 HTTP（repo 横断書込の濫用経路）|
| `gh auth token` | トークン平文出力（ログや他プロセスへ漏洩）|
| `gh auth login/logout/refresh` | 認証状態の操作 |
| `gh secret` / `gh variable` | repo secret/variable の読取・変更 |
| `gh workflow run/enable/disable` | CI 任意起動・状態変更（CI 経由 RCE）|
| `gh ssh-key` / `gh gpg-key` | 永続化鍵の追加 |

### chmod 拡張

既存の `chmod 777` 単独チェックを以下に拡張:

- 数値: `777`, `666`, `4xxx`（setuid）, `2xxx`（setgid）, `6xxx`（setuid+setgid）, `7xxx`（sticky+SUID+SGID）
- シンボリック: `u+s`, `g+s`, `+s`
- 再帰: `-R 777`, `-R 666`

setuid/setgid バイナリ作成は権限昇格の直接経路。コンテナ内 `node` ユーザー環境でも、sudo 可能な init-firewall 経由等で悪用されうる。

## 検証

`bash /tmp/hook-tests/run-tests.sh` でディスパッチテスト:

```
PASS [block]    gh-api -> exit 2
PASS [block]    gh-auth-token -> exit 2
PASS [block]    gh-secret -> exit 2
PASS [block]    gh-workflow-run -> exit 2
PASS [block]    chmod-setuid-sym -> exit 2
PASS [block]    chmod-setuid-num -> exit 2
PASS [block]    chmod-recursive-777 -> exit 2
PASS [allow]    chmod-ok -> exit 0          # chmod 755 は通る
PASS [allow]    gh-pr-list-ok -> exit 0     # gh pr list は通る
PASS [allow]    git-status-ok -> exit 0
PASS=10 FAIL=0
```

- `bash -n` 構文チェック OK
- 正常系（`chmod 755`, `gh pr list`, `git status`）はすべて exit 0

## Test plan

- [x] dispatch テスト 7 ブロック + 3 許可
- [x] bash syntax 検証
- [ ] 実際の Claude Code セッション内で `gh api /user` を要求して hook がブロックすることをマニュアル確認
- [ ] `chmod u+s /tmp/x` でブロックされることをマニュアル確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
