### PR TITLE
chore: Java 環境をデフォルト無効化（ビルド高速化）

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -90,7 +90,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # --- Java environment (optional, controlled by ENABLE_JAVA build arg) ---
-ARG ENABLE_JAVA=true
+# Java を使わないプロジェクトのビルドを高速化するためデフォルトは無効。
+# 有効化するには docker compose build --build-arg ENABLE_JAVA=true もしくは
+# .env で ENABLE_JAVA=true を設定する。
+ARG ENABLE_JAVA=false
 
 # Install Java (Eclipse Temurin JDK 21)
 RUN if [ "$ENABLE_JAVA" = "true" ]; then \

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ claude-dev-env/
 | Docker | Docker CLI + Docker Compose plugin（ホストの Docker ソケットをマウント） |
 | データベース | postgresql-client |
 | Python | Python 3.12, uv, langfuse, pip-audit |
-| Java | Eclipse Temurin JDK 21, Maven 3.9, Gradle 8.12（`ENABLE_JAVA=false` で無効化可） |
+| Java | Eclipse Temurin JDK 21, Maven 3.9, Gradle 8.12（**デフォルト無効**。`ENABLE_JAVA=true` で有効化） |
 | MCP サーバー | Context7 (ドキュメント検索), Playwright (ブラウザ自動化), Serena (セマンティックコード解析) |
 | 言語サーバー | typescript-language-server, pyright, jdtls (Serena 用) |
 | ユーザー | `node` (非 root) |
@@ -287,7 +287,7 @@ dev コンテナ (Claude Code + gh CLI)
 | **メモリ** | 8GB 以上推奨（Docker Desktop に 4GB 以上を割り当て） |
 | **ディスク** | 空き容量 10GB 以上（ビルド後イメージ: 約 3–5GB） |
 
-> **Java 無効化でビルドを高速化**: Java を使わないプロジェクトでは `.env` に `ENABLE_JAVA=false` を設定すると、JDK・Maven・Gradle のインストールがスキップされ、ビルド時間とイメージサイズを大幅に削減できます。
+> **Java はデフォルト無効**: ビルド高速化のため JDK・Maven・Gradle・jdtls のインストールはデフォルトで行わない。Java を使うプロジェクトでは `.env` に `ENABLE_JAVA=true` を設定するか `docker compose build --build-arg ENABLE_JAVA=true` でビルドする。
 
 #### ソフトウェア
 
@@ -470,7 +470,7 @@ gh issue create --title "Bug: fix crash" --label bug
 | Python | Python 3.12 + uv | Ruff | Ruff format | MyPy | Pyright |
 | Java | Eclipse Temurin JDK 21, Maven 3.9, Gradle 8.12 | - | - | - | jdtls (Eclipse JDT Language Server) |
 
-> Java 環境は `ENABLE_JAVA=false` で無効化可能。Java を使わないプロジェクトではビルド時間を短縮できる。
+> Java 環境は **デフォルトでは無効**（ビルド高速化のため）。利用するには `.env` で `ENABLE_JAVA=true` を設定するか、`docker compose build --build-arg ENABLE_JAVA=true` でビルドする。
 
 ### VS Code 拡張（自動インストール）
 

--- a/docker-compose-without-litellm.yml
+++ b/docker-compose-without-litellm.yml
@@ -38,6 +38,7 @@ services:
         CLAUDE_CODE_VERSION: latest
         GIT_DELTA_VERSION: "0.18.2"
         ZSH_IN_DOCKER_VERSION: "1.2.0"
+        ENABLE_JAVA: "${ENABLE_JAVA:-false}"
         # HTTP_PROXY: ${HTTP_PROXY:-}
         # HTTPS_PROXY: ${HTTPS_PROXY:-}
         # NO_PROXY: ${NO_PROXY:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
         TZ: Asia/Tokyo
         GIT_DELTA_VERSION: "0.18.2"
         ZSH_IN_DOCKER_VERSION: "1.2.0"
-        ENABLE_JAVA: "${ENABLE_JAVA:-true}"
+        ENABLE_JAVA: "${ENABLE_JAVA:-false}"
         # HTTP_PROXY: ${HTTP_PROXY:-}
         # HTTPS_PROXY: ${HTTPS_PROXY:-}
         # NO_PROXY: ${NO_PROXY:-}

--- a/workspace/CLAUDE.md
+++ b/workspace/CLAUDE.md
@@ -55,6 +55,8 @@
 | Python                  | 3.12             | uv                   | Ruff     | Ruff format |
 | Java                    | JDK 21 (Temurin) | Maven / Gradle       | -        | -           |
 
+> Java はビルド高速化のためデフォルト無効。`.env` で `ENABLE_JAVA=true` を設定したコンテナでのみ JDK / Maven / Gradle / jdtls がインストールされる。
+
 ### MCP サーバー（利用可能）
 
 - **Context7** — ライブラリのドキュメント・コード例をリアルタイム検索


### PR DESCRIPTION
## Summary

- `ENABLE_JAVA` のデフォルトを `true` → `false` に変更
- JDK 21 / Maven 3.9 / Gradle 8.12 / jdtls (Eclipse JDT Language Server) のインストールがスキップされ、ビルド時間とイメージサイズを大幅に削減
- Java を使うプロジェクトでは `.env` で `ENABLE_JAVA=true` を設定するか `docker compose build --build-arg ENABLE_JAVA=true`

## 変更ファイル

| ファイル | 変更 |
|---|---|
| `.devcontainer/Dockerfile` | `ARG ENABLE_JAVA=true` → `false` + コメント追加 |
| `docker-compose.yml` | `${ENABLE_JAVA:-true}` → `${ENABLE_JAVA:-false}` |
| `docker-compose-without-litellm.yml` | `ENABLE_JAVA: "${ENABLE_JAVA:-false}"` を args に追加（パリティ確保）|
| `README.md` | 3 箇所の文言を「デフォルト有効」→「デフォルト無効・opt-in」に反転 |
| `workspace/CLAUDE.md` | Java 行の下に注記を追加 |

## 動機

ユーザー報告: jdtls (`https://download.eclipse.org/jdtls/...`) のダウンロードがビルド中に長時間かかる。Java を使わないプロジェクトでは無駄なため、デフォルトを反転して opt-in にする。

## Test plan

- [x] `docker compose build` が Java 関連ステップをスキップする（`if [ "$ENABLE_JAVA" = "true" ]` が false になる）
- [x] `docker compose build --build-arg ENABLE_JAVA=true` で従来どおり Java 一式が入る
- [x] `.env` に `ENABLE_JAVA=true` を書いた場合も従来どおり Java 一式が入る
- [x] without-litellm 構成でも同じデフォルトで動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)