### PR TITLE
security(hook): supply-chain-guard.sh に lockfile / hash mode チェックを追加

### DIFF
--- a/.claude/hooks/supply-chain-guard.sh
+++ b/.claude/hooks/supply-chain-guard.sh
@@ -3,12 +3,13 @@
 # Exit 0 = allow, Exit 2 = block
 #
 # 4 層チェック:
-#   1. パッケージインストールコマンドの検出
-#   2. typosquatting 検知（人気パッケージとの類似度）
+#   1. lockfile / hash mode 確認（再現性確保、本ガードの早期実行）
+#   2. パッケージインストールコマンドの検出
 #   3. 悪意パターン検出（危険なキーワード）
-#   4. （将来）lockfile 存在確認、クールダウン設定確認
+#   4. typosquatting 検知（人気パッケージとの類似度）
 #
 # 無効化: ENABLE_SUPPLY_CHAIN_GUARD=false
+# lockfile チェックのみ無効化: SKIP_LOCKFILE_CHECK=true
 
 set -uo pipefail
 
@@ -23,6 +24,69 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 
 if [ -z "$COMMAND" ]; then
   exit 0
+fi
+
+
+# === lockfile / hash mode チェック ===
+# transitive 依存の再現性が無いと、毎回最新版が取得され攻撃の入り口となる。
+# パッケージ名抽出より前に走らせるのは、`npm install`（引数なし）や `uv sync`
+# のように specific package 引数を持たないコマンドも対象に含めるため。
+if [ "${SKIP_LOCKFILE_CHECK:-false}" != "true" ]; then
+  CHECK_DIR="${PWD:-/workspace}"
+
+  block_lockfile() {
+    local mgr="$1" required="$2" hint="$3"
+    echo "{\"decision\": \"block\", \"reason\": \"Blocked: ${mgr} requires ${required} for reproducible install. ${hint}\"}" >&2
+    exit 2
+  }
+
+  warn_hash_mode() {
+    local req_file="$1"
+    if [ -f "$req_file" ]; then
+      if ! grep -qE '\-\-require-hashes|\-\-hash=' "$req_file"; then
+        echo "[supply-chain-guard] WARN: ${req_file} has no --require-hashes / --hash= entries. Hash pinning is recommended for reproducibility." >&2
+      fi
+    fi
+  }
+
+  # npm: install / i / add は lockfile 必須、ci は素通し
+  if echo "$COMMAND" | grep -qE '^\s*npm\s+ci(\b|$)'; then
+    : # npm ci 自体が lockfile 必須なので OK
+  elif echo "$COMMAND" | grep -qE '^\s*npm\s+(install|i|add)(\b|$)'; then
+    if [ ! -f "$CHECK_DIR/package-lock.json" ] && [ ! -f "$CHECK_DIR/npm-shrinkwrap.json" ]; then
+      block_lockfile "npm" "package-lock.json" \
+        "Run 'npm install --package-lock-only' to bootstrap, or use 'npm ci' if a lockfile exists."
+    fi
+  fi
+
+  # uv: add / sync は uv.lock 必須
+  if echo "$COMMAND" | grep -qE '^\s*uv\s+(add|sync)(\b|$)'; then
+    if [ ! -f "$CHECK_DIR/uv.lock" ]; then
+      block_lockfile "uv" "uv.lock" \
+        "Run 'uv lock' to create the lockfile first."
+    fi
+  fi
+
+  # uv pip install: -r requirements は hash mode 警告、単体パッケージは uv.lock 必須
+  if echo "$COMMAND" | grep -qE '^\s*uv\s+pip\s+install(\b|$)'; then
+    REQ_FILE=$(echo "$COMMAND" | grep -oE '\-r\s+\S+' | head -1 | awk '{print $2}')
+    if [ -n "$REQ_FILE" ]; then
+      warn_hash_mode "$REQ_FILE"
+    else
+      if [ ! -f "$CHECK_DIR/uv.lock" ]; then
+        block_lockfile "uv pip install" "uv.lock" \
+          "Use 'uv add <pkg>' inside a uv-managed project, or pass '-r requirements.txt' with --require-hashes."
+      fi
+    fi
+  fi
+
+  # pip install: -r requirements の場合のみ hash mode 警告（単体パッケージは lockfile 概念なし）
+  if echo "$COMMAND" | grep -qE '^\s*pip3?\s+install(\b|$)'; then
+    REQ_FILE=$(echo "$COMMAND" | grep -oE '\-r\s+\S+' | head -1 | awk '{print $2}')
+    if [ -n "$REQ_FILE" ]; then
+      warn_hash_mode "$REQ_FILE"
+    fi
+  fi
 fi
 
 # --- パッケージインストールコマンドの検出 ---

--- a/.claude/tests/hook-test.sh
+++ b/.claude/tests/hook-test.sh
@@ -204,6 +204,9 @@ section "2" "supply-chain-guard.sh — サプライチェーンガード"
 
 # 環境変数を一時的に設定
 export ENABLE_SUPPLY_CHAIN_GUARD=true
+# 以降のセクションは typosquatting / 悪意パターン検出のみを検証するため
+# lockfile チェックを無効化する。lockfile チェック自体は後段の専用セクションで検証。
+export SKIP_LOCKFILE_CHECK=true
 
 echo -e "  ${YELLOW}--- ブロックされるべきコマンド（typosquatting）---${NC}"
 
@@ -272,6 +275,114 @@ test_hook "$GUARD_HOOK" "npm install expresss" 0 \
   "typosquatting: ENABLE_SUPPLY_CHAIN_GUARD=false で許可"
 
 export ENABLE_SUPPLY_CHAIN_GUARD=true
+# lockfile チェック専用セクションでは SKIP_LOCKFILE_CHECK を解除して有効化
+unset SKIP_LOCKFILE_CHECK
+
+echo ""
+echo -e "  ${YELLOW}--- lockfile / hash mode チェック ---${NC}"
+
+LOCKFILE_TEST_DIR="${TMPDIR:-/tmp}/lockfile-hook-test-$$"
+mkdir -p "$LOCKFILE_TEST_DIR/no-lock"
+mkdir -p "$LOCKFILE_TEST_DIR/with-npm" && touch "$LOCKFILE_TEST_DIR/with-npm/package-lock.json"
+mkdir -p "$LOCKFILE_TEST_DIR/with-shrink" && touch "$LOCKFILE_TEST_DIR/with-shrink/npm-shrinkwrap.json"
+mkdir -p "$LOCKFILE_TEST_DIR/with-uv" && touch "$LOCKFILE_TEST_DIR/with-uv/uv.lock"
+
+mkdir -p "$LOCKFILE_TEST_DIR/req-no-hash"
+echo 'requests==2.31.0' > "$LOCKFILE_TEST_DIR/req-no-hash/requirements.txt"
+
+mkdir -p "$LOCKFILE_TEST_DIR/req-with-hash"
+cat > "$LOCKFILE_TEST_DIR/req-with-hash/requirements.txt" <<'REQ_EOF'
+requests==2.31.0 \
+    --hash=sha256:abc123def456
+REQ_EOF
+
+# 指定 cwd で hook を呼び出すヘルパー
+test_hook_in_dir() {
+  local hook_path="$1"
+  local cwd="$2"
+  local command="$3"
+  local expected_exit="$4"
+  local description="$5"
+
+  local input
+  input=$(jq -n --arg cmd "$command" '{"tool_input": {"command": $cmd}}')
+
+  local exit_code=0
+  ( cd "$cwd" && echo "$input" | bash "$hook_path" >/dev/null 2>/dev/null ) || exit_code=$?
+
+  if [ "$exit_code" -eq "$expected_exit" ]; then
+    if [ "$expected_exit" -eq 2 ]; then
+      pass "BLOCK: $description"
+    else
+      pass "ALLOW: $description"
+    fi
+  else
+    if [ "$expected_exit" -eq 2 ]; then
+      fail "BLOCK 期待だが ALLOW された: $description (exit=$exit_code)"
+    else
+      fail "ALLOW 期待だが BLOCK された: $description (exit=$exit_code)"
+    fi
+  fi
+}
+
+# npm
+test_hook_in_dir "$GUARD_HOOK" "$LOCKFILE_TEST_DIR/no-lock" "npm install express" 2 \
+  "npm install <pkg>: package-lock.json 不在 → BLOCK"
+
+test_hook_in_dir "$GUARD_HOOK" "$LOCKFILE_TEST_DIR/with-npm" "npm install express" 0 \
+  "npm install <pkg>: package-lock.json あり → ALLOW"
+
+test_hook_in_dir "$GUARD_HOOK" "$LOCKFILE_TEST_DIR/with-shrink" "npm install express" 0 \
+  "npm install <pkg>: npm-shrinkwrap.json でも代替可"
+
+test_hook_in_dir "$GUARD_HOOK" "$LOCKFILE_TEST_DIR/no-lock" "npm i express" 2 \
+  "npm i 短縮形: lockfile 不在 → BLOCK"
+
+test_hook_in_dir "$GUARD_HOOK" "$LOCKFILE_TEST_DIR/no-lock" "npm install" 2 \
+  "npm install (引数なし): lockfile 不在 → BLOCK"
+
+test_hook_in_dir "$GUARD_HOOK" "$LOCKFILE_TEST_DIR/no-lock" "npm ci" 0 \
+  "npm ci: lockfile 不要で素通し（コマンド自体が lockfile 必須）"
+
+# uv
+test_hook_in_dir "$GUARD_HOOK" "$LOCKFILE_TEST_DIR/no-lock" "uv add fastapi" 2 \
+  "uv add: uv.lock 不在 → BLOCK"
+
+test_hook_in_dir "$GUARD_HOOK" "$LOCKFILE_TEST_DIR/with-uv" "uv add fastapi" 0 \
+  "uv add: uv.lock あり → ALLOW"
+
+test_hook_in_dir "$GUARD_HOOK" "$LOCKFILE_TEST_DIR/no-lock" "uv sync" 2 \
+  "uv sync: uv.lock 不在 → BLOCK"
+
+test_hook_in_dir "$GUARD_HOOK" "$LOCKFILE_TEST_DIR/with-uv" "uv sync" 0 \
+  "uv sync: uv.lock あり → ALLOW"
+
+test_hook_in_dir "$GUARD_HOOK" "$LOCKFILE_TEST_DIR/no-lock" "uv pip install httpx" 2 \
+  "uv pip install <pkg>: uv.lock 不在 → BLOCK"
+
+test_hook_in_dir "$GUARD_HOOK" "$LOCKFILE_TEST_DIR/with-uv" "uv pip install httpx" 0 \
+  "uv pip install <pkg>: uv.lock あり → ALLOW"
+
+# pip / uv pip -r requirements: 警告のみ (exit 0)
+test_hook_in_dir "$GUARD_HOOK" "$LOCKFILE_TEST_DIR/req-no-hash" "pip install -r requirements.txt" 0 \
+  "pip install -r (hash 無): exit 0 で警告のみ"
+
+test_hook_in_dir "$GUARD_HOOK" "$LOCKFILE_TEST_DIR/req-with-hash" "pip install -r requirements.txt" 0 \
+  "pip install -r (hash 有): exit 0"
+
+test_hook_in_dir "$GUARD_HOOK" "$LOCKFILE_TEST_DIR/no-lock" "pip install requests" 0 \
+  "pip install <pkg>: 単体は lockfile 概念なし → ALLOW"
+
+test_hook_in_dir "$GUARD_HOOK" "$LOCKFILE_TEST_DIR/req-no-hash" "uv pip install -r requirements.txt" 0 \
+  "uv pip install -r (hash 無): exit 0 で警告のみ（uv.lock 不要）"
+
+# 無効化スイッチ
+export SKIP_LOCKFILE_CHECK=true
+test_hook_in_dir "$GUARD_HOOK" "$LOCKFILE_TEST_DIR/no-lock" "npm install express" 0 \
+  "SKIP_LOCKFILE_CHECK=true: lockfile チェックを skip"
+unset SKIP_LOCKFILE_CHECK
+
+rm -rf "$LOCKFILE_TEST_DIR"
 
 # =============================================================================
 # 3. gha-security-check.sh テスト

--- a/workspace/.claude/hooks/supply-chain-guard.sh
+++ b/workspace/.claude/hooks/supply-chain-guard.sh
@@ -3,12 +3,13 @@
 # Exit 0 = allow, Exit 2 = block
 #
 # 4 層チェック:
-#   1. パッケージインストールコマンドの検出
-#   2. typosquatting 検知（人気パッケージとの類似度）
+#   1. lockfile / hash mode 確認（再現性確保、本ガードの早期実行）
+#   2. パッケージインストールコマンドの検出
 #   3. 悪意パターン検出（危険なキーワード）
-#   4. （将来）lockfile 存在確認、クールダウン設定確認
+#   4. typosquatting 検知（人気パッケージとの類似度）
 #
 # 無効化: ENABLE_SUPPLY_CHAIN_GUARD=false
+# lockfile チェックのみ無効化: SKIP_LOCKFILE_CHECK=true
 
 set -uo pipefail
 
@@ -23,6 +24,69 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 
 if [ -z "$COMMAND" ]; then
   exit 0
+fi
+
+
+# === lockfile / hash mode チェック ===
+# transitive 依存の再現性が無いと、毎回最新版が取得され攻撃の入り口となる。
+# パッケージ名抽出より前に走らせるのは、`npm install`（引数なし）や `uv sync`
+# のように specific package 引数を持たないコマンドも対象に含めるため。
+if [ "${SKIP_LOCKFILE_CHECK:-false}" != "true" ]; then
+  CHECK_DIR="${PWD:-/workspace}"
+
+  block_lockfile() {
+    local mgr="$1" required="$2" hint="$3"
+    echo "{\"decision\": \"block\", \"reason\": \"Blocked: ${mgr} requires ${required} for reproducible install. ${hint}\"}" >&2
+    exit 2
+  }
+
+  warn_hash_mode() {
+    local req_file="$1"
+    if [ -f "$req_file" ]; then
+      if ! grep -qE '\-\-require-hashes|\-\-hash=' "$req_file"; then
+        echo "[supply-chain-guard] WARN: ${req_file} has no --require-hashes / --hash= entries. Hash pinning is recommended for reproducibility." >&2
+      fi
+    fi
+  }
+
+  # npm: install / i / add は lockfile 必須、ci は素通し
+  if echo "$COMMAND" | grep -qE '^\s*npm\s+ci(\b|$)'; then
+    : # npm ci 自体が lockfile 必須なので OK
+  elif echo "$COMMAND" | grep -qE '^\s*npm\s+(install|i|add)(\b|$)'; then
+    if [ ! -f "$CHECK_DIR/package-lock.json" ] && [ ! -f "$CHECK_DIR/npm-shrinkwrap.json" ]; then
+      block_lockfile "npm" "package-lock.json" \
+        "Run 'npm install --package-lock-only' to bootstrap, or use 'npm ci' if a lockfile exists."
+    fi
+  fi
+
+  # uv: add / sync は uv.lock 必須
+  if echo "$COMMAND" | grep -qE '^\s*uv\s+(add|sync)(\b|$)'; then
+    if [ ! -f "$CHECK_DIR/uv.lock" ]; then
+      block_lockfile "uv" "uv.lock" \
+        "Run 'uv lock' to create the lockfile first."
+    fi
+  fi
+
+  # uv pip install: -r requirements は hash mode 警告、単体パッケージは uv.lock 必須
+  if echo "$COMMAND" | grep -qE '^\s*uv\s+pip\s+install(\b|$)'; then
+    REQ_FILE=$(echo "$COMMAND" | grep -oE '\-r\s+\S+' | head -1 | awk '{print $2}')
+    if [ -n "$REQ_FILE" ]; then
+      warn_hash_mode "$REQ_FILE"
+    else
+      if [ ! -f "$CHECK_DIR/uv.lock" ]; then
+        block_lockfile "uv pip install" "uv.lock" \
+          "Use 'uv add <pkg>' inside a uv-managed project, or pass '-r requirements.txt' with --require-hashes."
+      fi
+    fi
+  fi
+
+  # pip install: -r requirements の場合のみ hash mode 警告（単体パッケージは lockfile 概念なし）
+  if echo "$COMMAND" | grep -qE '^\s*pip3?\s+install(\b|$)'; then
+    REQ_FILE=$(echo "$COMMAND" | grep -oE '\-r\s+\S+' | head -1 | awk '{print $2}')
+    if [ -n "$REQ_FILE" ]; then
+      warn_hash_mode "$REQ_FILE"
+    fi
+  fi
 fi
 
 # --- パッケージインストールコマンドの検出 ---


### PR DESCRIPTION
## Summary

`supply-chain-guard.sh` に **lockfile / hash mode チェック** を追加。Closes #31。

transitive 依存の再現性が確保されないと、毎回最新版が解決されてサプライチェーン攻撃の入り口になるため、lockfile 不在の install を block する。

## 動作マトリクス

| コマンド | 必要ファイル | 失敗時 |
|---|---|---|
| `npm install <pkg>` / `npm i` / `npm add` / `npm install`（引数なし）| `package-lock.json` または `npm-shrinkwrap.json` | exit 2 |
| `npm ci` | （素通し）| - |
| `uv add <pkg>` / `uv sync` | `uv.lock` | exit 2 |
| `uv pip install <pkg>` | `uv.lock` | exit 2 |
| `pip install -r requirements.txt` | `--require-hashes` または `--hash=` | **警告のみ** (exit 0) |
| `uv pip install -r requirements.txt` | 同上 | **警告のみ** |
| `pip install <pkg>` 単体 | （lockfile 概念なし、素通し）| - |

## 設計上の決定

- **lockfile チェックを package 名抽出より前に配置**: `npm install`（引数なし）や `uv sync` は package 引数を持たないため、既存の早期 exit パスではチェックが走らなかった。lockfile 検査を最前段に移動して取りこぼしを排除
- **緊急バイパス**: `SKIP_LOCKFILE_CHECK=true` で lockfile チェックのみ無効化（ガード全体の `ENABLE_SUPPLY_CHAIN_GUARD=false` とは独立）
- **shrinkwrap 対応**: `npm-shrinkwrap.json` も lockfile として認識

## テスト

`.claude/tests/hook-test.sh` に **17 ケース** を追加:

```
[2] supply-chain-guard.sh — サプライチェーンガード
  --- lockfile / hash mode チェック ---
  ✓ BLOCK: npm install <pkg>: package-lock.json 不在 → BLOCK
  ✓ ALLOW: npm install <pkg>: package-lock.json あり → ALLOW
  ✓ ALLOW: npm install <pkg>: npm-shrinkwrap.json でも代替可
  ✓ BLOCK: npm i 短縮形: lockfile 不在 → BLOCK
  ✓ BLOCK: npm install (引数なし): lockfile 不在 → BLOCK
  ✓ ALLOW: npm ci: lockfile 不要で素通し
  ✓ BLOCK: uv add: uv.lock 不在 → BLOCK
  ✓ ALLOW: uv add: uv.lock あり → ALLOW
  ✓ BLOCK: uv sync: uv.lock 不在 → BLOCK
  ✓ ALLOW: uv sync: uv.lock あり → ALLOW
  ✓ BLOCK: uv pip install <pkg>: uv.lock 不在 → BLOCK
  ✓ ALLOW: uv pip install <pkg>: uv.lock あり → ALLOW
  ✓ ALLOW: pip install -r (hash 無): exit 0 で警告のみ
  ✓ ALLOW: pip install -r (hash 有): exit 0
  ✓ ALLOW: pip install <pkg>: 単体は lockfile 概念なし
  ✓ ALLOW: uv pip install -r (hash 無): exit 0 で警告のみ
  ✓ ALLOW: SKIP_LOCKFILE_CHECK=true: lockfile チェックを skip
```

既存の typosquatting / 悪意パターン検出テストは `SKIP_LOCKFILE_CHECK=true` で囲って lockfile チェックの干渉を排除。**全 87 テスト合格**。

```
==========================================
Hook テスト結果
==========================================
  PASS: 87
  FAIL: 0
  TOTAL: 87
```

## 参考

- 監査レポート対応 3（Medium 優先）
- supply-chain-guard.sh の 4 層チェックの 4 番目を実装

🤖 Generated with [Claude Code](https://claude.com/claude-code)
