### PR TITLE
security(hook): dockerfile-cooldown-check.sh に opt-in PreToolUse block を追加

### DIFF
--- a/.claude/hooks/dockerfile-cooldown-check.sh
+++ b/.claude/hooks/dockerfile-cooldown-check.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# dockerfile-cooldown-check.sh — PostToolUse Hook for Edit/Write
+# dockerfile-cooldown-check.sh — Pre/PostToolUse Hook for Edit/Write
 # Dockerfile の編集・作成時にクールダウン設定の有無をチェックする。
 #
 # 検出対象:
@@ -7,15 +7,31 @@
 #   - pip install に --uploaded-prior-to がないケース
 #   - uv pip install / uv add に --exclude-newer がないケース
 #
-# Exit 0 = 常に成功（ブロックはしない、警告のみ）
+# モード:
+#   --pre 引数あり (PreToolUse 用): tool_input から「変更後の内容」を再構築してチェック。
+#     ENABLE_DOCKERFILE_COOLDOWN_BLOCK=true のときに警告があれば exit 2 でブロック、
+#     それ以外（デフォルト）はサイレント exit 0（PostToolUse 側で警告される）
+#   --pre 引数なし (PostToolUse 用): 従来どおりディスクのファイルを読んで警告のみ
 #
 # 無効化: ENABLE_SUPPLY_CHAIN_GUARD=false
+# Pre ブロック有効化: ENABLE_DOCKERFILE_COOLDOWN_BLOCK=true（デフォルト false = 警告のみ）
 
 set -euo pipefail
 
 # ON/OFF 制御
 if [ "${ENABLE_SUPPLY_CHAIN_GUARD:-true}" = "false" ]; then
   exit 0
+fi
+
+# --- モード判定 ---
+HOOK_MODE="post"
+if [ "${1:-}" = "--pre" ]; then
+  HOOK_MODE="pre"
+  # Pre モードはオプトイン: ENABLE_DOCKERFILE_COOLDOWN_BLOCK=true のときだけ動作。
+  # それ以外はサイレント exit 0（警告は PostToolUse が出力する。二重表示を避ける）
+  if [ "${ENABLE_DOCKERFILE_COOLDOWN_BLOCK:-false}" != "true" ]; then
+    exit 0
+  fi
 fi
 
 # stdin から tool_input を読み取る
@@ -39,14 +55,56 @@ if [ -z "$IS_DOCKERFILE" ]; then
   exit 0
 fi
 
-# ファイルが存在しない場合はスキップ
-if [ ! -f "$FILE_PATH" ]; then
-  exit 0
+# Pre モード: tool_input から「変更後の内容」を再構築する
+# Post モード: ディスク上のファイルを読む（従来動作）
+if [ "$HOOK_MODE" = "pre" ]; then
+  TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+  case "$TOOL_NAME" in
+    Write)
+      # 新規 / 上書き: tool_input.content がそのまま反映される内容
+      RAW_CONTENT=$(echo "$INPUT" | jq -r '.tool_input.content // empty' 2>/dev/null)
+      ;;
+    Edit)
+      # 部分置換: 現状ファイル + old_string→new_string の置換結果
+      OLD_STR=$(echo "$INPUT" | jq -r '.tool_input.old_string // empty' 2>/dev/null)
+      NEW_STR=$(echo "$INPUT" | jq -r '.tool_input.new_string // empty' 2>/dev/null)
+      REPLACE_ALL=$(echo "$INPUT" | jq -r '.tool_input.replace_all // false' 2>/dev/null)
+      if [ ! -f "$FILE_PATH" ]; then
+        # 編集対象が存在しない（理論的には Edit では起きないが念のため）
+        exit 0
+      fi
+      RAW_CONTENT=$(python3 - "$FILE_PATH" "$OLD_STR" "$NEW_STR" "$REPLACE_ALL" << 'PYEOF'
+import sys
+path, old, new, replace_all = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+with open(path, 'r') as f:
+    text = f.read()
+if replace_all == "true":
+    text = text.replace(old, new)
+else:
+    text = text.replace(old, new, 1)
+sys.stdout.write(text)
+PYEOF
+)
+      ;;
+    *)
+      # 想定外のツール: スキップ
+      exit 0
+      ;;
+  esac
+  if [ -z "$RAW_CONTENT" ]; then
+    exit 0
+  fi
+else
+  # Post モード: ファイルが存在しない場合はスキップ
+  if [ ! -f "$FILE_PATH" ]; then
+    exit 0
+  fi
 fi
 
 # === Dockerfile の内容をチェック ===
 
 WARNINGS=""
+WARN_LEVEL_HIT=""  # [WARN] エントリのみ block 対象。[INFO] は警告のみ。
 HEADER_SHOWN=""
 
 show_header() {
@@ -63,11 +121,20 @@ add_warning() {
   show_header
   echo "  $1" >&2
   WARNINGS="true"
+  case "$1" in
+    *"[WARN]"*)
+      WARN_LEVEL_HIT="true"
+      ;;
+  esac
 }
 
 # RUN 命令を抽出（複数行の継続 \ を結合）
 # sed: 行末の \ を除去して次行と結合
-DOCKERFILE_CONTENT=$(sed ':a;/\\$/N;s/\\\n//;ta' "$FILE_PATH" 2>/dev/null || cat "$FILE_PATH")
+if [ "$HOOK_MODE" = "pre" ]; then
+  DOCKERFILE_CONTENT=$(printf '%s' "$RAW_CONTENT" | sed ':a;/\\$/N;s/\\\n//;ta')
+else
+  DOCKERFILE_CONTENT=$(sed ':a;/\\$/N;s/\\\n//;ta' "$FILE_PATH" 2>/dev/null || cat "$FILE_PATH")
+fi
 
 # --- npm install / npm ci チェック ---
 npm_lines=$(echo "$DOCKERFILE_CONTENT" | grep -n 'npm\s\+\(install\|ci\|i\)\b' 2>/dev/null || true)
@@ -168,7 +235,7 @@ if [ -n "$npm_lines" ]; then
   fi
 fi
 
-# === サマリー ===
+# === サマリー / 判定 ===
 if [ -n "$HEADER_SHOWN" ]; then
   echo "==========================================" >&2
   if [ -n "$WARNINGS" ]; then
@@ -176,6 +243,13 @@ if [ -n "$HEADER_SHOWN" ]; then
     echo "    .devcontainer/Dockerfile" >&2
   fi
   echo "" >&2
+fi
+
+# Pre モード + ブロック有効 + WARN レベル警告ありなら exit 2
+# （INFO レベル：npm/pip 自体のアップグレード推奨等はブロックしない）
+if [ "$HOOK_MODE" = "pre" ] && [ -n "$WARN_LEVEL_HIT" ] && [ "${ENABLE_DOCKERFILE_COOLDOWN_BLOCK:-false}" = "true" ]; then
+  echo "{\"decision\": \"block\", \"reason\": \"Blocked: Dockerfile lacks cooldown settings (npm min-release-age / pip --uploaded-prior-to / uv --exclude-newer). Add cooldown directives or set ENABLE_DOCKERFILE_COOLDOWN_BLOCK=false to skip.\"}" >&2
+  exit 2
 fi
 
 exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -216,6 +216,24 @@
             "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/supply-chain-guard.sh"
           }
         ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/dockerfile-cooldown-check.sh --pre"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/dockerfile-cooldown-check.sh --pre"
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/.claude/tests/hook-test.sh
+++ b/.claude/tests/hook-test.sh
@@ -591,6 +591,151 @@ test_hook "$AUDIT_HOOK" "npm install express" 0 \
 export ENABLE_SUPPLY_CHAIN_GUARD=true
 
 # =============================================================================
+# 5. dockerfile-cooldown-check.sh — PreToolUse / PostToolUse 両モード
+# =============================================================================
+section "5" "dockerfile-cooldown-check.sh — クールダウン block (opt-in)"
+
+DOCKERFILE_HOOK="${BASE_DIR}/hooks/dockerfile-cooldown-check.sh"
+DF_TEST_DIR="${TMPDIR:-/tmp}/dockerfile-cooldown-test-$$"
+mkdir -p "$DF_TEST_DIR"
+
+# クールダウン未指定の Dockerfile
+DF_BAD="$DF_TEST_DIR/Dockerfile.bad"
+cat > "$DF_BAD" <<'EOF'
+FROM node:24
+RUN npm install -g typescript
+RUN pip install requests
+EOF
+
+# クールダウン指定済みの Dockerfile
+DF_GOOD="$DF_TEST_DIR/Dockerfile.good"
+cat > "$DF_GOOD" <<'EOF'
+FROM node:24
+RUN npm config set -g min-release-age 7
+RUN npm install -g --ignore-scripts typescript
+RUN pip install --upgrade pip && pip install --uploaded-prior-to=2026-04-18 --only-binary :all: requests
+EOF
+
+# 非 Dockerfile（hook 対象外）
+NON_DF="$DF_TEST_DIR/script.sh"
+echo "echo hello" > "$NON_DF"
+
+# Pre モード用ヘルパー: tool_name + tool_input を JSON で渡す
+test_pre_hook() {
+  local tool_name="$1"
+  local file_path="$2"
+  local jq_input="$3"
+  local block_env="$4"   # "true" or "" (unset)
+  local expected_exit="$5"
+  local description="$6"
+
+  local input
+  input=$(jq -n \
+    --arg tn "$tool_name" \
+    --arg fp "$file_path" \
+    --argjson ti "$jq_input" \
+    '{"tool_name": $tn, "tool_input": ($ti + {"file_path": $fp})}')
+
+  local exit_code=0
+  # サブシェルで env を export しないと pipe 先の bash には伝わらない
+  if [ -n "$block_env" ]; then
+    ( export ENABLE_DOCKERFILE_COOLDOWN_BLOCK=true; echo "$input" | bash "$DOCKERFILE_HOOK" --pre >/dev/null 2>/dev/null ) || exit_code=$?
+  else
+    ( unset ENABLE_DOCKERFILE_COOLDOWN_BLOCK; echo "$input" | bash "$DOCKERFILE_HOOK" --pre >/dev/null 2>/dev/null ) || exit_code=$?
+  fi
+
+  if [ "$exit_code" -eq "$expected_exit" ]; then
+    if [ "$expected_exit" -eq 2 ]; then
+      pass "BLOCK: $description"
+    else
+      pass "ALLOW: $description"
+    fi
+  else
+    if [ "$expected_exit" -eq 2 ]; then
+      fail "BLOCK 期待だが exit=$exit_code: $description"
+    else
+      fail "ALLOW 期待だが exit=$exit_code: $description"
+    fi
+  fi
+}
+
+# 既存 Bad Dockerfile を上書きする Write を想定したコンテンツ
+BAD_CONTENT_JSON=$(jq -Rs '{"content": .}' < "$DF_BAD")
+GOOD_CONTENT_JSON=$(jq -Rs '{"content": .}' < "$DF_GOOD")
+
+echo -e "  ${YELLOW}--- PreToolUse Write: クールダウン block ---${NC}"
+
+test_pre_hook "Write" "$DF_TEST_DIR/Dockerfile" "$BAD_CONTENT_JSON" "true" 2 \
+  "Write Dockerfile (cooldown 無) + ENABLE_DOCKERFILE_COOLDOWN_BLOCK=true → BLOCK"
+
+test_pre_hook "Write" "$DF_TEST_DIR/Dockerfile" "$GOOD_CONTENT_JSON" "true" 0 \
+  "Write Dockerfile (cooldown 有) + ENABLE_DOCKERFILE_COOLDOWN_BLOCK=true → ALLOW"
+
+test_pre_hook "Write" "$DF_TEST_DIR/Dockerfile" "$BAD_CONTENT_JSON" "" 0 \
+  "Write Dockerfile (cooldown 無) + 環境変数未設定 → ALLOW silent (PostToolUse で警告)"
+
+echo ""
+echo -e "  ${YELLOW}--- PreToolUse Edit: クールダウン block ---${NC}"
+
+# Edit は file_path に既存の "bad" Dockerfile があり、それを new で置換するシナリオ
+EDIT_TO_BAD_JSON=$(jq -n '{"old_string": "FROM node:24", "new_string": "FROM node:24\nRUN npm install -g lodash"}')
+EDIT_TO_GOOD_JSON=$(jq -n '{"old_string": "RUN npm install -g typescript", "new_string": "RUN npm install -g --ignore-scripts --min-release-age=7 typescript"}')
+
+test_pre_hook "Edit" "$DF_BAD" "$EDIT_TO_BAD_JSON" "true" 2 \
+  "Edit Dockerfile (cooldown 無の追加) + BLOCK=true → BLOCK"
+
+test_pre_hook "Edit" "$DF_BAD" "$EDIT_TO_GOOD_JSON" "true" 2 \
+  "Edit Dockerfile (typescript 行は修正しても pip 行が cooldown 無) → BLOCK"
+
+# good Dockerfile に対する Edit は問題なし
+EDIT_GOOD_NOOP=$(jq -n '{"old_string": "FROM node:24", "new_string": "FROM node:24"}')
+test_pre_hook "Edit" "$DF_GOOD" "$EDIT_GOOD_NOOP" "true" 0 \
+  "Edit Dockerfile (cooldown 有 + 変更なし) + BLOCK=true → ALLOW"
+
+echo ""
+echo -e "  ${YELLOW}--- 非 Dockerfile / 無効化スイッチ ---${NC}"
+
+test_pre_hook "Write" "$NON_DF" "$BAD_CONTENT_JSON" "true" 0 \
+  "Write 非 Dockerfile: 対象外 → ALLOW"
+
+# ENABLE_SUPPLY_CHAIN_GUARD=false で全体無効化
+input_disabled=$(jq -n --arg fp "$DF_TEST_DIR/Dockerfile" --argjson ti "$BAD_CONTENT_JSON" \
+  '{"tool_name": "Write", "tool_input": ($ti + {"file_path": $fp})}')
+exit_code=0
+ENABLE_SUPPLY_CHAIN_GUARD=false ENABLE_DOCKERFILE_COOLDOWN_BLOCK=true \
+  bash -c "echo '$input_disabled' | bash '$DOCKERFILE_HOOK' --pre >/dev/null 2>/dev/null" || exit_code=$?
+if [ "$exit_code" -eq 0 ]; then
+  pass "ALLOW: ENABLE_SUPPLY_CHAIN_GUARD=false で全体スルー"
+else
+  fail "ENABLE_SUPPLY_CHAIN_GUARD=false が効かない (exit=$exit_code)"
+fi
+
+echo ""
+echo -e "  ${YELLOW}--- PostToolUse モード（従来動作維持）---${NC}"
+
+# Post モードはディスク上のファイルを読む
+input_post_bad=$(jq -n --arg fp "$DF_BAD" '{"tool_input": {"file_path": $fp}}')
+exit_code=0
+echo "$input_post_bad" | bash "$DOCKERFILE_HOOK" >/dev/null 2>/dev/null || exit_code=$?
+if [ "$exit_code" -eq 0 ]; then
+  pass "ALLOW: Post モード（cooldown 無）→ exit 0 + 警告のみ"
+else
+  fail "Post モードで exit=$exit_code（警告のみのはず）"
+fi
+
+input_post_good=$(jq -n --arg fp "$DF_GOOD" '{"tool_input": {"file_path": $fp}}')
+exit_code=0
+echo "$input_post_good" | bash "$DOCKERFILE_HOOK" >/dev/null 2>/dev/null || exit_code=$?
+if [ "$exit_code" -eq 0 ]; then
+  pass "ALLOW: Post モード（cooldown 有）→ exit 0 警告なし"
+else
+  fail "Post モード（cooldown 有）で exit=$exit_code"
+fi
+
+# 後片付け
+rm -rf "$DF_TEST_DIR"
+
+# =============================================================================
 # 結果サマリー
 # =============================================================================
 echo ""

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
 ENABLE_JAVA=
+# Dockerfile cooldown PreToolUse block (opt-in, default false = warning only)
+# true に設定すると cooldown 設定が無い Dockerfile 編集を exit 2 で block する
+ENABLE_DOCKERFILE_COOLDOWN_BLOCK=
 # 指定のポート以外は通さないように設定する
 FIREWALL_ALLOWED_PORTS=
 

--- a/README.md
+++ b/README.md
@@ -707,6 +707,19 @@ bash cooldown_management/cooldown-update.sh 3
 ENABLE_SUPPLY_CHAIN_GUARD=false
 ```
 
+### Dockerfile クールダウンチェックを block モード化（オプトイン）
+
+デフォルトでは `dockerfile-cooldown-check.sh` は **警告のみ**（PostToolUse、`exit 0`）で、Dockerfile 編集自体はブロックしない。
+クールダウン未指定の Dockerfile 編集を強制的に止めたい場合は、以下を `.env` に追加してオプトインする:
+
+```env
+ENABLE_DOCKERFILE_COOLDOWN_BLOCK=true
+```
+
+有効化すると PreToolUse で Edit/Write が走るときに Dockerfile の内容を検査し、`[WARN]` レベル
+（npm `--ignore-scripts` / `--min-release-age`、pip `--uploaded-prior-to`、uv `--exclude-newer` の不在）が
+あれば `exit 2` でブロックする。`[INFO]` レベル（npm/pip 自体のアップグレード推奨）はブロックしない。
+
 ## セキュリティテスト
 
 本環境のセキュリティ対策が正しく機能しているかを検証するためのテストを用意している。

--- a/docker-compose-without-litellm.yml
+++ b/docker-compose-without-litellm.yml
@@ -64,6 +64,8 @@ services:
       - CLAUDE_CONFIG_DIR=/home/node/.claude
       - GITHUB_TOKEN=${GITHUB_TOKEN:-}
       - ENABLE_FIREWALL=${ENABLE_FIREWALL:-true}
+      # Dockerfile cooldown PreToolUse block (opt-in, default false = warning only)
+      - ENABLE_DOCKERFILE_COOLDOWN_BLOCK=${ENABLE_DOCKERFILE_COOLDOWN_BLOCK:-false}
       - HOST_WORKSPACE_PATH=${PWD}/workspace
       # docker / docker compose は docker-proxy 経由で実行（socket 直接マウントを廃止）
       - DOCKER_HOST=tcp://docker-proxy:2375

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,6 +119,9 @@ services:
       - HOST_WORKSPACE_PATH=${PWD}/workspace
       # Supply Chain Guard (set ENABLE_SUPPLY_CHAIN_GUARD=false in .env to disable)
       - ENABLE_SUPPLY_CHAIN_GUARD=${ENABLE_SUPPLY_CHAIN_GUARD:-true}
+      # Dockerfile cooldown PreToolUse block (opt-in, default false = warning only)
+      # true に設定すると、cooldown 設定なしの Dockerfile 編集を exit 2 で block する
+      - ENABLE_DOCKERFILE_COOLDOWN_BLOCK=${ENABLE_DOCKERFILE_COOLDOWN_BLOCK:-false}
       # LangFuse tracing for Claude Code hook (set TRACE_TO_LANGFUSE=true in .env to enable)
       # CC_LANGFUSE_* は Claude Code Hook 専用。アプリ側の LANGFUSE_* と競合しない
       - TRACE_TO_LANGFUSE=${TRACE_TO_LANGFUSE:-false}

--- a/workspace/.claude/settings.json
+++ b/workspace/.claude/settings.json
@@ -231,6 +231,24 @@
             "command": "bash /workspace/.claude/hooks/supply-chain-guard.sh"
           }
         ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /workspace/.claude/hooks/dockerfile-cooldown-check.sh --pre"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /workspace/.claude/hooks/dockerfile-cooldown-check.sh --pre"
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/workspace/CLAUDE.md
+++ b/workspace/CLAUDE.md
@@ -179,7 +179,7 @@ uv run pytest              # テスト
 |------|------|---------|-----------|--------|-----------|
 | `block-dangerous.sh` | PreToolUse(Bash) | 全 Bash コマンド | 0=許可, 2=ブロック | ツール実行をブロック | jq |
 | `supply-chain-guard.sh` | PreToolUse(Bash) | `npm install`, `pip install`, `uv add` 等 | 0=許可, 2=ブロック | ツール実行をブロック | jq, python3 |
-| `dockerfile-cooldown-check.sh` | PostToolUse(Edit/Write) | `Dockerfile*` の編集・作成 | 常に 0 | 警告のみ | - |
+| `dockerfile-cooldown-check.sh` | Pre/PostToolUse(Edit/Write) | `Dockerfile*` の編集・作成 | post: 0、pre: 0 or 2 | post 警告のみ。`ENABLE_DOCKERFILE_COOLDOWN_BLOCK=true` で pre 時に WARN を block | - |
 | `gha-security-check.sh` | PostToolUse(Edit/Write) | `.github/workflows/*.yml` の編集・作成 | 常に 0 | 警告のみ | jq |
 | `lint-on-save.sh` | PostToolUse(Edit) | `.py`, `.js`, `.ts`, `.jsx`, `.tsx` の編集 | 常に 0 | サイレント | ruff, eslint, prettier |
 | `supply-chain-audit.sh` | PostToolUse(Bash) | パッケージインストールコマンド実行後 | 常に 0 | 警告のみ | npm, pip-audit |
@@ -190,7 +190,7 @@ uv run pytest              # テスト
 
 - **block-dangerous.sh** — `rm -rf /`, `curl`, `wget`, `nc`, リバースシェル、base64 難読化、設定ファイル改竄、Sandbox バイパスなど 28 パターンを検出・ブロック
 - **supply-chain-guard.sh** — 4 層チェック: (1) lockfile 存在確認、(2) typosquatting 検知（レーベンシュタイン距離）、(3) 悪意パターンブロック、(4) クールダウン設定確認。`ENABLE_SUPPLY_CHAIN_GUARD=false` で無効化可能
-- **dockerfile-cooldown-check.sh** — Dockerfile 内の `npm install`, `pip install`, `uv pip install` にクールダウン設定が適用されているか警告
+- **dockerfile-cooldown-check.sh** — Dockerfile 内の `npm install`, `pip install`, `uv pip install` にクールダウン設定が適用されているか検査。デフォルトは PostToolUse 警告のみ。`ENABLE_DOCKERFILE_COOLDOWN_BLOCK=true` で PreToolUse モードが有効化され、`[WARN]` レベル違反を `exit 2` でブロック
 - **gha-security-check.sh** — スクリプトインジェクション、`pull_request_target` + HEAD checkout、シークレット漏洩、`write-all` 権限など 10 項目を検出
 - **lint-on-save.sh** — Python: `ruff check --fix` + `ruff format`、JS/TS: `eslint --fix` + `prettier --write`（利用可能な場合のみ）
 - **supply-chain-audit.sh** — `npm audit` / `pip-audit` を自動実行し、脆弱性件数をサマリ表示


### PR DESCRIPTION
## Summary

`dockerfile-cooldown-check.sh` に **opt-in の PreToolUse block** を追加。Closes #32。

デフォルトは従来どおり警告のみ。`.env` で `ENABLE_DOCKERFILE_COOLDOWN_BLOCK=true` を設定したプロジェクトだけ、クールダウン未指定の Dockerfile 編集を `exit 2` で block する。

## 動作マトリクス

| シナリオ | 環境変数 | 挙動 |
|---|---|---|
| Dockerfile を Write/Edit、cooldown 設定あり | 何でも | PreToolUse pass、PostToolUse 警告なし、`exit 0` |
| Dockerfile を Write/Edit、cooldown 未指定 | `ENABLE_DOCKERFILE_COOLDOWN_BLOCK` 未設定 | PreToolUse silent、PostToolUse 警告、`exit 0` |
| Dockerfile を Write/Edit、cooldown 未指定 | `ENABLE_DOCKERFILE_COOLDOWN_BLOCK=true` | PreToolUse が `[WARN]` 検出 → JSON block reason + `exit 2` |
| 非 Dockerfile を Write/Edit | 何でも | hook 対象外、`exit 0` |
| `ENABLE_SUPPLY_CHAIN_GUARD=false` | - | hook 全体スキップ |

## 設計のポイント

- **Pre/Post 統合 hook**: 既存スクリプトに `--pre` フラグを追加して同一実装を Pre/Post 両方で再利用
- **Pre モードはオプトイン**: env 未設定なら早期 `exit 0` で何もしない（PostToolUse の警告と二重表示しない）
- **WARN レベルのみ block**: `[INFO]`（npm/pip 自体のアップグレード推奨）は block 対象外。`[WARN]` レベル（クールダウン未指定）のみ block トリガ
- **Write はそのまま、Edit は置換結果を再構築**: Edit では `old_string→new_string` の置換結果を Python で構築してから検査。`replace_all` 対応

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `.claude/hooks/dockerfile-cooldown-check.sh` | `--pre` フラグ + WARN/INFO 分離 + Pre モード silent default |
| `.claude/settings.json` | PreToolUse Write/Edit を追加 |
| `workspace/.claude/settings.json` | 同上（コンテナ側） |
| `.claude/tests/hook-test.sh` | section [5] を追加（11 ケース）|
| `docker-compose.yml` / `docker-compose-without-litellm.yml` | `ENABLE_DOCKERFILE_COOLDOWN_BLOCK` の env passthrough |
| `.env.example` | opt-in 説明 |
| `README.md` | 「Dockerfile クールダウンチェックを block モード化」セクション追加 |
| `workspace/CLAUDE.md` | Hooks 一覧表を Pre/Post 両対応に更新 |

## テスト

`.claude/tests/hook-test.sh` に **section [5]** を追加（11 ケース）。

```
[5] dockerfile-cooldown-check.sh — クールダウン block (opt-in)
  --- PreToolUse Write: クールダウン block ---
  ✓ BLOCK: Write Dockerfile (cooldown 無) + ENABLE_DOCKERFILE_COOLDOWN_BLOCK=true → BLOCK
  ✓ ALLOW: Write Dockerfile (cooldown 有) + ENABLE_DOCKERFILE_COOLDOWN_BLOCK=true → ALLOW
  ✓ ALLOW: Write Dockerfile (cooldown 無) + 環境変数未設定 → ALLOW silent

  --- PreToolUse Edit: クールダウン block ---
  ✓ BLOCK: Edit Dockerfile (cooldown 無の追加) + BLOCK=true → BLOCK
  ✓ BLOCK: Edit Dockerfile (typescript 行は修正しても pip 行が cooldown 無)
  ✓ ALLOW: Edit Dockerfile (cooldown 有 + 変更なし) → ALLOW

  --- 非 Dockerfile / 無効化スイッチ ---
  ✓ ALLOW: Write 非 Dockerfile → ALLOW
  ✓ ALLOW: ENABLE_SUPPLY_CHAIN_GUARD=false で全体スルー

  --- PostToolUse モード（従来動作維持）---
  ✓ ALLOW: Post モード（cooldown 無）→ exit 0 + 警告のみ
  ✓ ALLOW: Post モード（cooldown 有）→ exit 0 警告なし
```

**全 97 テスト合格** (PASS:97 / FAIL:0)

## 受入基準（Issue #32）

- [x] `ENABLE_DOCKERFILE_COOLDOWN_BLOCK=true` のとき、クールダウン未指定の Dockerfile 編集が exit 2 でブロック
- [x] デフォルト（環境変数未設定）では従来どおり警告のみ
- [x] `docker-compose.yml` / `.env.example` に環境変数の説明を追加
- [x] dispatch テスト追加（クールダウン指定あり/なしの Dockerfile）
- [x] CLAUDE.md / README にオプトイン手順を記載

🤖 Generated with [Claude Code](https://claude.com/claude-code)
