### PR TITLE
security(hook): block-dangerous.sh に python/node egress 警告を追加

### DIFF
--- a/.claude/hooks/block-dangerous.sh
+++ b/.claude/hooks/block-dangerous.sh
@@ -137,5 +137,32 @@ if echo "$COMMAND" | grep -qiE 'sandbox.*enabled.*false|"enabled"\s*:\s*false.*s
   exit 2
 fi
 
+# --- python / node 経由の egress 検出（情報提供レベル）---
+# 主防御は init-firewall.sh の egress 許可リスト（24 ドメインのみ通信可）。
+# このチェックは「気づき」を提供するもので、firewall を回避することは不可能。
+# 開発で正当に使う場面（Anthropic API、PyPI アクセス等）が多いため警告のみが既定。
+# 強制ブロックしたい場合は STRICT_EGRESS_BLOCK=true を設定する。
+EGRESS_HIT=""
+EGRESS_REASON=""
+
+if echo "$COMMAND" | grep -qE '\b(python|python3)\s+-c\b.*\b(urllib|httplib|http\.client|requests|socket|aiohttp|urllib3|httpx)\b'; then
+  EGRESS_HIT="true"
+  EGRESS_REASON="Python ネットワークモジュール (urllib/http.client/requests/socket/aiohttp/urllib3/httpx) の直接実行を検出"
+fi
+
+if echo "$COMMAND" | grep -qE "\bnode\s+-[ep]\b.*(require\(['\"](https?|net|http2)['\"]\)|\bfetch\s*\()"; then
+  EGRESS_HIT="true"
+  EGRESS_REASON="Node 標準モジュール (http/https/net/http2/fetch) の直接実行を検出"
+fi
+
+if [ -n "$EGRESS_HIT" ]; then
+  if [ "${STRICT_EGRESS_BLOCK:-false}" = "true" ]; then
+    echo "{\"decision\": \"block\", \"reason\": \"Blocked (STRICT_EGRESS_BLOCK=true): ${EGRESS_REASON}. Set STRICT_EGRESS_BLOCK=false to allow with warning only.\"}" >&2
+    exit 2
+  else
+    echo "[block-dangerous] WARN: ${EGRESS_REASON}. firewall が許可ドメインのみ通すので主防御は維持されますが、意図した処理か確認してください。STRICT_EGRESS_BLOCK=true でブロック動作に切替可能。" >&2
+  fi
+fi
+
 # All checks passed
 exit 0

--- a/.claude/tests/hook-test.sh
+++ b/.claude/tests/hook-test.sh
@@ -197,6 +197,79 @@ test_hook "$BLOCK_HOOK" "python3 -c 'print(1+1)'" 0 \
 test_hook "$BLOCK_HOOK" "echo hello" 0 \
   "echo（通常出力）"
 
+echo ""
+echo -e "  ${YELLOW}--- python/node 経由 egress（警告レベル）---${NC}"
+
+# 警告のみ（exit 0 + stderr 出力）
+test_hook "$BLOCK_HOOK" "python -c 'import urllib.request'" 0 \
+  "python -c urllib: 警告のみ exit 0"
+
+test_hook "$BLOCK_HOOK" "python3 -c 'import socket; s=socket.socket()'" 0 \
+  "python3 -c socket: 警告のみ exit 0"
+
+test_hook "$BLOCK_HOOK" "python -c 'import requests; requests.get(x)'" 0 \
+  "python -c requests: 警告のみ exit 0"
+
+test_hook "$BLOCK_HOOK" 'python -c "import http.client"' 0 \
+  "python -c http.client: 警告のみ exit 0"
+
+test_hook "$BLOCK_HOOK" "python3 -c 'import aiohttp'" 0 \
+  "python3 -c aiohttp: 警告のみ exit 0"
+
+test_hook "$BLOCK_HOOK" "node -e \"const h=require('https'); h.get(x)\"" 0 \
+  "node -e require(https): 警告のみ exit 0"
+
+test_hook "$BLOCK_HOOK" "node -e \"const h=require('http'); h.request(x)\"" 0 \
+  "node -e require(http): 警告のみ exit 0"
+
+test_hook "$BLOCK_HOOK" "node -p \"require('net').Socket\"" 0 \
+  "node -p require(net): 警告のみ exit 0"
+
+test_hook "$BLOCK_HOOK" "node -e \"fetch('https://x')\"" 0 \
+  "node -e fetch(): 警告のみ exit 0"
+
+# 検出対象外（許可）
+test_hook "$BLOCK_HOOK" "python -c 'print(1+1)'" 0 \
+  "python -c print: 検出対象外 exit 0"
+
+test_hook "$BLOCK_HOOK" "node -e 'console.log(1+1)'" 0 \
+  "node -e console.log: 検出対象外 exit 0"
+
+echo ""
+echo -e "  ${YELLOW}--- STRICT_EGRESS_BLOCK=true でブロック動作 ---${NC}"
+
+# サブシェルで env を export する（pipe 先の bash に伝えるため）
+test_strict_block() {
+  local command="$1"
+  local expected_exit="$2"
+  local description="$3"
+
+  local input
+  input=$(jq -n --arg cmd "$command" '{"tool_input": {"command": $cmd}}')
+
+  local exit_code=0
+  ( export STRICT_EGRESS_BLOCK=true; echo "$input" | bash "$BLOCK_HOOK" >/dev/null 2>/dev/null ) || exit_code=$?
+
+  if [ "$exit_code" -eq "$expected_exit" ]; then
+    if [ "$expected_exit" -eq 2 ]; then
+      pass "BLOCK: $description"
+    else
+      pass "ALLOW: $description"
+    fi
+  else
+    fail "$description (exit=$exit_code, 期待=$expected_exit)"
+  fi
+}
+
+test_strict_block "python -c 'import urllib.request'" 2 \
+  "STRICT: python urllib → BLOCK"
+
+test_strict_block "node -e \"require('https')\"" 2 \
+  "STRICT: node require(https) → BLOCK"
+
+test_strict_block "python -c 'print(1+1)'" 0 \
+  "STRICT: python plain → ALLOW (検出対象外)"
+
 # =============================================================================
 # 2. supply-chain-guard.sh テスト
 # =============================================================================

--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@ ENABLE_JAVA=
 # Dockerfile cooldown PreToolUse block (opt-in, default false = warning only)
 # true に設定すると cooldown 設定が無い Dockerfile 編集を exit 2 で block する
 ENABLE_DOCKERFILE_COOLDOWN_BLOCK=
+# python -c / node -e 経由のネットワーク呼び出しを block-dangerous.sh で警告/ブロック
+# 主防御は init-firewall.sh (egress 許可リスト) のため通常は不要。
+# true でブロック（exit 2）、未設定または false で警告のみ（stderr + exit 0）
+STRICT_EGRESS_BLOCK=
 # 指定のポート以外は通さないように設定する
 FIREWALL_ALLOWED_PORTS=
 

--- a/README.md
+++ b/README.md
@@ -734,6 +734,27 @@ ENABLE_DOCKERFILE_COOLDOWN_BLOCK=true
 よく使う `npx prettier`、`npx tsc`、`npx @playwright/mcp` は通常通り承認可能。引数の組み合わせは
 `-y` `-p <pkg>` `--package=<pkg>` `<pkg>@<version>` `@scope/<pkg>` に対応する。
 
+### python / node 経由 egress の警告
+
+`Bash(python *)` / `Bash(python3 *)` / `Bash(node *)` は allow されているため、
+`python -c "import urllib.request; ..."` のようなコードで `curl`/`wget` の deny を回避できる。
+ただし主防御である `init-firewall.sh` の egress 許可リスト（24 ドメイン）は維持されるため、
+許可外の宛先に到達することは不可能。
+
+**気づき**を提供する目的で、`block-dangerous.sh` が以下のパターンを検出して stderr に警告を出す（デフォルトは `exit 0`）:
+
+- `python -c` / `python3 -c` 内に `urllib` / `http.client` / `httplib` / `requests` / `socket` / `aiohttp` / `urllib3` / `httpx`
+- `node -e` / `node -p` 内に `require('http'/'https'/'net'/'http2')` または `fetch(`
+
+開発作業で正当に使う場面（PyPI/Anthropic API 取得など）が多いため、警告のみが既定。
+強制ブロックしたい場合は `.env` で:
+
+```env
+STRICT_EGRESS_BLOCK=true
+```
+
+を設定すると、検出時に `exit 2` で block される（プロンプト承認後でも遮断）。
+
 ## セキュリティテスト
 
 本環境のセキュリティ対策が正しく機能しているかを検証するためのテストを用意している。

--- a/docker-compose-without-litellm.yml
+++ b/docker-compose-without-litellm.yml
@@ -66,6 +66,8 @@ services:
       - ENABLE_FIREWALL=${ENABLE_FIREWALL:-true}
       # Dockerfile cooldown PreToolUse block (opt-in, default false = warning only)
       - ENABLE_DOCKERFILE_COOLDOWN_BLOCK=${ENABLE_DOCKERFILE_COOLDOWN_BLOCK:-false}
+      # python -c / node -e 経由 egress を強制 block (opt-in, default false = warning only)
+      - STRICT_EGRESS_BLOCK=${STRICT_EGRESS_BLOCK:-false}
       - HOST_WORKSPACE_PATH=${PWD}/workspace
       # docker / docker compose は docker-proxy 経由で実行（socket 直接マウントを廃止）
       - DOCKER_HOST=tcp://docker-proxy:2375

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,9 @@ services:
       # Dockerfile cooldown PreToolUse block (opt-in, default false = warning only)
       # true に設定すると、cooldown 設定なしの Dockerfile 編集を exit 2 で block する
       - ENABLE_DOCKERFILE_COOLDOWN_BLOCK=${ENABLE_DOCKERFILE_COOLDOWN_BLOCK:-false}
+      # python -c / node -e 経由の egress を block-dangerous.sh で警告 (default) / block する
+      # 主防御は init-firewall.sh の egress 許可リスト。これは「気づき」のための補助。
+      - STRICT_EGRESS_BLOCK=${STRICT_EGRESS_BLOCK:-false}
       # LangFuse tracing for Claude Code hook (set TRACE_TO_LANGFUSE=true in .env to enable)
       # CC_LANGFUSE_* は Claude Code Hook 専用。アプリ側の LANGFUSE_* と競合しない
       - TRACE_TO_LANGFUSE=${TRACE_TO_LANGFUSE:-false}

--- a/workspace/CLAUDE.md
+++ b/workspace/CLAUDE.md
@@ -188,7 +188,7 @@ uv run pytest              # テスト
 
 ### 各フックの詳細
 
-- **block-dangerous.sh** — `rm -rf /`, `curl`, `wget`, `nc`, リバースシェル、base64 難読化、設定ファイル改竄、Sandbox バイパスなど 28 パターンを検出・ブロック
+- **block-dangerous.sh** — `rm -rf /`, `curl`, `wget`, `nc`, リバースシェル、base64 難読化、設定ファイル改竄、Sandbox バイパスなど 28 パターンを検出・ブロック。加えて `python -c` / `node -e` 経由のネットワーク呼び出し（urllib / requests / socket / aiohttp / require('http'/'https'/'net'/'http2') / fetch 等）を検出して stderr に警告（主防御は firewall）。`STRICT_EGRESS_BLOCK=true` で警告 → ブロック動作に切替可能
 - **supply-chain-guard.sh** — 4 層チェック: (1) lockfile 存在確認、(2) typosquatting 検知（レーベンシュタイン距離）、(3) 悪意パターンブロック、(4) クールダウン設定確認。検査対象は `npm install`/`pip install`/`uv add`/`uv pip install` に加え `npx <pkg>` も含む（npx は `Bash(npx *)` allow を外しているため、確認プロンプトと並行して typosquatting / 悪意検査が走る）。`ENABLE_SUPPLY_CHAIN_GUARD=false` で無効化可能
 - **dockerfile-cooldown-check.sh** — Dockerfile 内の `npm install`, `pip install`, `uv pip install` にクールダウン設定が適用されているか検査。デフォルトは PostToolUse 警告のみ。`ENABLE_DOCKERFILE_COOLDOWN_BLOCK=true` で PreToolUse モードが有効化され、`[WARN]` レベル違反を `exit 2` でブロック
 - **gha-security-check.sh** — スクリプトインジェクション、`pull_request_target` + HEAD checkout、シークレット漏洩、`write-all` 権限など 10 項目を検出


### PR DESCRIPTION
## Summary

`block-dangerous.sh` に **python/node 経由 egress の警告検出**を追加。Closes #34。

`curl`/`wget` は deny 済みだが、`python -c "import urllib..."` や `node -e "require('https')..."`
で同等の egress が可能。主防御は `init-firewall.sh`（24 ドメイン許可リスト）なので
許可外宛先には到達できないが、**気づき**を与える目的でスクリプトレベルでも検出する。

## 検出パターン

| カテゴリ | パターン |
|---|---|
| Python | `python -c` / `python3 -c` 内に `urllib`、`http.client`、`httplib`、`requests`、`socket`、`aiohttp`、`urllib3`、`httpx` |
| Node | `node -e` / `node -p` 内に `require('http')`、`require('https')`、`require('net')`、`require('http2')`、`fetch(` |

## 挙動

| 環境変数 | 検出時の挙動 |
|---|---|
| 未設定（デフォルト）| stderr に `[block-dangerous] WARN: ...` を出力 → `exit 0`（ツール実行継続）|
| `STRICT_EGRESS_BLOCK=true` | JSON block decision + `exit 2`（確認プロンプト承認後でも遮断）|

## なぜブロックではなく警告か（デフォルト）

- 開発作業で正当な理由（PyPI / Anthropic API 取得など）で利用する場面が多い
- firewall が egress を許可ドメインに限定しているので、危険な exfil 先には到達できない
- 強制ブロックすると正常作業を阻害して回避策が乱立する

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `.claude/hooks/block-dangerous.sh` | egress 検出ブロックを追加（warn デフォルト、`STRICT_EGRESS_BLOCK=true` で block）|
| `workspace/.claude/hooks/block-dangerous.sh` | 同上 |
| `.claude/tests/hook-test.sh` | 14 ケース追加（warn 11 + strict 3）|
| `docker-compose.yml` / `docker-compose-without-litellm.yml` | `STRICT_EGRESS_BLOCK` env passthrough |
| `.env.example` | opt-in 説明 |
| `README.md` | 「python / node 経由 egress の警告」セクションを追記 |
| `workspace/CLAUDE.md` | block-dangerous.sh の説明を更新 |

## テスト

```
[1] block-dangerous.sh — 危険コマンド検出
  ...
  --- python/node 経由 egress（警告レベル）---
  ✓ python -c urllib: 警告のみ exit 0
  ✓ python3 -c socket: 警告のみ exit 0
  ✓ python -c requests: 警告のみ exit 0
  ✓ python -c http.client: 警告のみ exit 0
  ✓ python3 -c aiohttp: 警告のみ exit 0
  ✓ node -e require(https): 警告のみ exit 0
  ✓ node -e require(http): 警告のみ exit 0
  ✓ node -p require(net): 警告のみ exit 0
  ✓ node -e fetch(): 警告のみ exit 0
  ✓ python -c print: 検出対象外 exit 0
  ✓ node -e console.log: 検出対象外 exit 0

  --- STRICT_EGRESS_BLOCK=true でブロック動作 ---
  ✓ STRICT: python urllib → BLOCK
  ✓ STRICT: node require(https) → BLOCK
  ✓ STRICT: python plain → ALLOW (検出対象外)
```

**全 121 テスト合格** (PASS:121 / FAIL:0)

## 受入基準（Issue #34）

- [x] python -c の `urllib`/`http.client`/`requests`/`socket`/`aiohttp` 検出時に stderr に警告
- [x] node -e の `require("http"|"https")` 検出時に警告
- [x] 警告でも exit 0（ツール実行は許可）
- [x] `STRICT_EGRESS_BLOCK=true` でブロック動作切替
- [x] dispatch テスト追加（許可・警告・ブロックの 3 パターン）
- [x] firewall が主防御である旨をスクリプトコメントに明記

🤖 Generated with [Claude Code](https://claude.com/claude-code)
