### PR TITLE
fix(devcontainer): SOPS を v3.12.2 に更新、age を distro パッケージに切替

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -50,20 +50,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   python3 \
   python3-pip \
   python3-venv \
+  age \
   ca-certificates \
   curl \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# --- SOPS + age（.env 暗号化・復号） ---
-# age は GitHub release から直接取得する（dl.filippo.io の単一障害点を避けるため）
+# --- SOPS（.env 暗号化・復号バックエンド） ---
+# SOPS は CNCF（旧 Mozilla）の getsops/sops 公式バイナリを GitHub release から取得
+# age 本体は distro パッケージで導入済み（Debian Bookworm の age 1.1.1、Layer 1 参照）
 ARG SOPS_VERSION=3.12.2
-ARG AGE_VERSION=1.2.1
 RUN ARCH=$(dpkg --print-architecture) && \
   curl -fsSL "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.${ARCH}" \
-  -o /usr/local/bin/sops && chmod +x /usr/local/bin/sops && \
-  curl -fsSL "https://github.com/FiloSottile/age/releases/download/v${AGE_VERSION}/age-v${AGE_VERSION}-linux-${ARCH}.tar.gz" \
-  | tar -xz --strip-components=1 -C /usr/local/bin/ && \
-  chmod +x /usr/local/bin/age /usr/local/bin/age-keygen
+  -o /usr/local/bin/sops && chmod +x /usr/local/bin/sops
 
 # --- Layer 2: ネットワーク・ファイアウォール ---
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -55,11 +55,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # --- SOPS + age（.env 暗号化・復号） ---
-ARG SOPS_VERSION=3.9.4
+# age は GitHub release から直接取得する（dl.filippo.io の単一障害点を避けるため）
+ARG SOPS_VERSION=3.12.2
+ARG AGE_VERSION=1.2.1
 RUN ARCH=$(dpkg --print-architecture) && \
   curl -fsSL "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.${ARCH}" \
   -o /usr/local/bin/sops && chmod +x /usr/local/bin/sops && \
-  curl -fsSL "https://dl.filippo.io/age/v1.2.1?for=linux/${ARCH}" | tar -xz --strip-components=1 -C /usr/local/bin/ && \
+  curl -fsSL "https://github.com/FiloSottile/age/releases/download/v${AGE_VERSION}/age-v${AGE_VERSION}-linux-${ARCH}.tar.gz" \
+  | tar -xz --strip-components=1 -C /usr/local/bin/ && \
   chmod +x /usr/local/bin/age /usr/local/bin/age-keygen
 
 # --- Layer 2: ネットワーク・ファイアウォール ---

--- a/workspace/.pip.conf
+++ b/workspace/.pip.conf
@@ -11,4 +11,4 @@ no-extra-index-url = true
 # pip は相対日付（P7D等）に未対応のため、絶対日付で指定する
 # この値は定期的に更新するか、コマンドラインで上書きすること:
 #   pip install --uploaded-prior-to=$(date -d '-7days' -Idate) <package>
-uploaded-prior-to = 2026-04-17
+uploaded-prior-to = 2026-04-18


### PR DESCRIPTION
## Summary

ビルド失敗（SOPS v3.9.4 の 502）を直すと同時に、age の取得経路を **個人配布チャンネルから distro パッケージに切り替え**ます。

- **SOPS**: v3.9.4 → **v3.12.2**（v3.9.4 の release asset が GitHub 側で恒久的 502 を返すため）
- **age**: GitHub release / `dl.filippo.io`（個人配布）→ **`apt install age`**（Debian Bookworm の age 1.1.1）
- **`AGE_VERSION` ARG を削除**（distro 側で管理）
- ついでに `workspace/.pip.conf` の `uploaded-prior-to` を 2026-04-18 に同期（`cooldown-update.sh` 由来）

## ビルド失敗ログ（修正前）

```
=> ERROR [dev  4/32] RUN ARCH=$(dpkg --print-architecture) && curl -fsSL "https://github.com/getsops/sops/releases/download/v3.9.4/sops-v3.9.4.linux.${ARCH}" ...
3.489 curl: (22) The requested URL returned error: 502
3.493 gzip: stdin: unexpected end of file
```

## 信頼境界の整理

| 依存 | 修正前 | 修正後 | 信頼境界 |
|---|---|---|---|
| SOPS | `getsops/sops` GitHub release | 同左 | **CNCF（旧 Mozilla）公式 org** |
| age | `dl.filippo.io`（個人ドメイン） | `apt install age` | **Debian maintainer**（DM/DD レビュー） |

> 個人配布バイナリ（`dl.filippo.io` / `FiloSottile/age` の release asset）を依存物として直接取得するのを避け、distro パッケージ経由に切替。配布チャンネルの信頼境界が distro maintainer に移る。

## 確認した事実

| URL | 状況 |
|---|---|
| `https://github.com/getsops/sops/releases/download/v3.9.4/sops-v3.9.4.linux.amd64` | **502 Bad Gateway**（3 回 retry すべて失敗、retroactive 不具合） |
| `https://github.com/getsops/sops/releases/download/v3.12.2/...` および v3.9.0 / 3.9.3 / 3.10.x / 3.11.0 | 200 OK |
| `https://dl.filippo.io/age/v1.2.1?for=linux/amd64` | timeout |
| Debian Bookworm の `age` package | 1.1.1-2（`packages.debian.org/bookworm/age`） |

## age バージョン低下の影響

- 修正前の age 1.2.1 → 修正後の age 1.1.1（distro 提供）
- age 1.x は安定 ABI、SOPS との互換性は問題なし（SOPS は age 1.0+ をサポート）
- `.env` 暗号化フォーマットも互換

## age 自体の依存判断

age は元 Go security チームの Filippo Valsorda が主要 maintainer で「個人」依存の側面はある。ただし:

- 仕様 (`age-encryption.org/v1`) が公開、独立実装あり（`rage` = Rust 実装）
- 暗号 primitive はすべて RFC 標準（X25519 / ChaCha20-Poly1305 / HKDF-SHA256 / scrypt）
- Mozilla SOPS で公式サポート、CNCF エコシステム（Flux, Argo CD など）で採用多数

**bus factor 観点での代替**（SOPS + PGP 等）は別 issue として構想登録予定。

## Test plan

- [x] `docker compose build dev` が成功すること
- [x] コンテナ内で `sops --version` が `3.12.2` を返すこと
- [x] コンテナ内で `age --version` が `1.1.1` を返すこと（distro 提供版）
- [x] `.env` の暗号化／復号フローが従来通り動くこと（既存 `start-devcontainer.sh` で確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
