### PR TITLE
refactor(devcontainer): bind mount target を /opt/claude-source に移動

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -44,5 +44,5 @@
     "CLAUDE_CONFIG_DIR": "/home/node/.claude",
     "POWERLEVEL9K_DISABLE_GITSTATUS": "true"
   },
-  "postStartCommand": "mkdir -p /workspace/.claude/hooks /workspace/.claude/tests && cp -f /workspace/.claude-source/hooks/* /workspace/.claude/hooks/ 2>/dev/null && cp -f /workspace/.claude-source/tests/* /workspace/.claude/tests/ 2>/dev/null && echo 'Hooks/tests synced from .claude-source' && /usr/local/bin/setup-mcp.sh && (sudo /usr/local/bin/init-firewall.sh || echo 'Firewall init skipped (requires NET_ADMIN capability)') && (bash /workspace/cooldown_management/cooldown-update.sh 7 || echo 'Cooldown update skipped') && (/usr/local/bin/decrypt-env.sh || echo 'env decrypt skipped')"
+  "postStartCommand": "mkdir -p /workspace/.claude/hooks /workspace/.claude/tests && cp -f /opt/claude-source/hooks/* /workspace/.claude/hooks/ 2>/dev/null && cp -f /opt/claude-source/tests/* /workspace/.claude/tests/ 2>/dev/null && echo 'Hooks/tests synced from /opt/claude-source' && /usr/local/bin/setup-mcp.sh && (sudo /usr/local/bin/init-firewall.sh || echo 'Firewall init skipped (requires NET_ADMIN capability)') && (bash /workspace/cooldown_management/cooldown-update.sh 7 || echo 'Cooldown update skipped') && (/usr/local/bin/decrypt-env.sh || echo 'env decrypt skipped')"
 }

--- a/docker-compose-without-litellm.yml
+++ b/docker-compose-without-litellm.yml
@@ -84,7 +84,7 @@ services:
       - /run/secrets:size=1m,mode=700,uid=1000,gid=1000
     volumes:
       - ./workspace:/workspace:delegated
-      - ./.claude:/workspace/.claude-source:ro
+      - ./.claude:/opt/claude-source:ro
       - ./cooldown_management:/workspace/cooldown_management:ro
       - claude-config:/home/node/.claude
       - bash-history:/commandhistory

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,7 +146,7 @@ services:
       - /run/secrets:size=1m,mode=700,uid=1000,gid=1000
     volumes:
       - ./workspace:/workspace:delegated
-      - ./.claude:/workspace/.claude-source:ro
+      - ./.claude:/opt/claude-source:ro
       - ./cooldown_management:/workspace/cooldown_management:ro
       - claude-config:/home/node/.claude
       - bash-history:/commandhistory


### PR DESCRIPTION
## Summary
- ホスト側 \`./workspace/\` に空の \`.claude-source/\` ディレクトリが Docker bind mount の副作用で生成されてしまう問題を解消
- bind mount target を \`/workspace/.claude-source\` から \`/opt/claude-source\` に移動し、ホスト側プレースホルダ生成を回避
- 機能影響なし（read-only mount、書き込み先の \`/workspace/.claude/\` は変更なし）

## 背景

\`/workspace\` 自体が \`./workspace\` の bind mount のため、その配下に bind mount target を作ると Docker がホスト側 \`./workspace/\` にも空ディレクトリを作成してしまう。これが \`workspace/.claude-source/\` の正体（\`.gitignore\` 済みだが見た目が冗長）。

マウント先を \`/workspace/\` の外（\`/opt/claude-source\`）に出すことでこの副作用を解消する。

## 変更内容

- \`docker-compose.yml\`: bind mount target を \`/opt/claude-source\` へ
- \`docker-compose-without-litellm.yml\`: 同上
- \`.devcontainer/devcontainer.json\`: \`postStartCommand\` の cp 元パスを更新

## マージ後のローカル後処理

DevContainer 再起動後、ホストの \`workspace/.claude-source/\` ディレクトリはもう作られない。既存の空ディレクトリは手動で削除可（\`.gitignore\` 済みなので git からは見えない）。

## Test plan
- [x] hook-test.sh 130/130 PASS（回帰防止）
- [ ] DevContainer rebuild 後、\`/opt/claude-source\` から hooks/tests がコピーされることを確認
- [ ] DevContainer rebuild 後、ホスト側 \`workspace/.claude-source/\` が再生成されないことを確認
- [ ] 既存の \`workspace/.claude/hooks\` 内ファイル（hook 群）が DevContainer 起動時に \`/opt/claude-source/hooks/\` から正しく上書き同期されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)