### PR TITLE
security(settings): sandbox バイパス経路を塞ぐ

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -137,6 +137,8 @@
   "sandbox": {
     "enabled": true,
     "autoAllowBashIfSandboxed": true,
+    "failIfUnavailable": true,
+    "allowUnsandboxedCommands": false,
     "excludedCommands": [
       "docker *",
       "gh *"


### PR DESCRIPTION
## Summary
- `allowUnsandboxedCommands=false` で危険パラメータ経由の sandbox バイパスを無効化
- `failIfUnavailable=true` で sandbox 起動失敗時のフォールバックも閉じる

Claude Code が sandbox 外でコマンド実行する 2 系統の経路を両方閉じる。

## Test plan
- [ ] DevContainer / ホスト両方で Claude Code 起動 → sandbox が常時有効化されることを確認
- [ ] 既存の hook-test.sh が引き続き PASS することを確認