### PR TITLE
feat(devcontainer): rtk CLI 出力圧縮プロキシを SHA256 ピン留めで導入

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -63,6 +63,26 @@ RUN ARCH=$(dpkg --print-architecture) && \
   curl -fsSL "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.${ARCH}" \
   -o /usr/local/bin/sops && chmod +x /usr/local/bin/sops
 
+# --- rtk（CLI 出力圧縮プロキシ、LLM トークン削減用） ---
+# 個人メンテのため SHA256 ピン留めで導入。signature/attestation は未発行のため
+# checksums.txt と GitHub TLS が信頼アンカー。RTK_VERSION 更新時は両 SHA を必ず差し替えること。
+# 取得元: https://github.com/rtk-ai/rtk/releases/download/v${RTK_VERSION}/checksums.txt
+# arm64 は musl ビルドが無いため glibc 版を使用（base image が glibc なので問題なし）
+ARG RTK_VERSION=0.38.0
+ARG RTK_SHA256_AMD64=9bafb356450fb0f66a7f2d68d0468d1b1e270163f1620574e67a4c8f816d9610
+ARG RTK_SHA256_ARM64=2e171f1d1c76086bb447e372d9332869d2cd3cc106c08c6e5fbd102b12e91ad9
+RUN ARCH=$(dpkg --print-architecture) && \
+  case "$ARCH" in \
+    amd64) TARGET=x86_64-unknown-linux-musl; SHA=$RTK_SHA256_AMD64 ;; \
+    arm64) TARGET=aarch64-unknown-linux-gnu;  SHA=$RTK_SHA256_ARM64 ;; \
+    *) echo "rtk: unsupported arch $ARCH" >&2; exit 1 ;; \
+  esac && \
+  curl -fsSL "https://github.com/rtk-ai/rtk/releases/download/v${RTK_VERSION}/rtk-${TARGET}.tar.gz" -o /tmp/rtk.tgz && \
+  echo "${SHA}  /tmp/rtk.tgz" | sha256sum -c - && \
+  tar -xzf /tmp/rtk.tgz -C /tmp && \
+  install -m0755 /tmp/rtk /usr/local/bin/rtk && \
+  rm -f /tmp/rtk.tgz /tmp/rtk
+
 # --- Layer 2: ネットワーク・ファイアウォール ---
 RUN apt-get update && apt-get install -y --no-install-recommends \
   iptables \


### PR DESCRIPTION
## Summary
- rtk-ai/rtk v0.38.0 (CLI 出力圧縮プロキシ、LLM トークン削減用) を DevContainer に追加
- amd64 = `x86_64-unknown-linux-musl`, arm64 = `aarch64-unknown-linux-gnu` を使用 (arm64 musl はリリース無し、base が glibc のため glibc 版で問題なし)
- 公式 `checksums.txt` の値で SHA256 ピン留めし、ビルド時に `sha256sum -c` で検証
- 取得 URL: `https://github.com/rtk-ai/rtk/releases/download/v${RTK_VERSION}/rtk-${TARGET}.tar.gz`

## Supply chain notes
- 個人メンテプロジェクトのため、信頼アンカーは「GitHub TLS で取得した checksums.txt」+「Dockerfile に固定した SHA256」の二段
- sigstore/SLSA attestation は未発行 (GitHub attestations API で 404 確認済み)
- バージョン更新時は **必ず両アーキの SHA を同時更新** すること

## Pinned digests (v0.38.0)
- amd64: `9bafb356450fb0f66a7f2d68d0468d1b1e270163f1620574e67a4c8f816d9610`
- arm64: `2e171f1d1c76086bb447e372d9332869d2cd3cc106c08c6e5fbd102b12e91ad9`

## Test plan
- [ ] `docker compose build dev` が amd64 ホストで成功する
- [ ] (Apple Silicon) arm64 ホストでも成功する
- [ ] コンテナ内で `rtk --version` が v0.38.0 を返す
- [ ] わざと SHA を 1 文字書き換えてビルドが落ちることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)