### PR TITLE
feat(devcontainer): base を node:24-trixie (glibc 2.41) へ更新

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,8 @@
 # ベースイメージを SHA256 ダイジェストでピン留め（サプライチェーン対策）
-# 更新時: docker pull node:24 && docker inspect --format='{{index .RepoDigests 0}}' node:24
-FROM node:24@sha256:80fc934952c8f1b2b4d39907af7211f8a9fff1a4c2cf673fb49099292c251cec
+# Trixie (Debian 13, glibc 2.41) を採用。Bookworm (glibc 2.36) では rtk arm64 バイナリが
+# GLIBC_2.39 必須のため実行不可だった経緯による（amd64 は musl 静的なので独立）。
+# 更新時: docker pull node:24-trixie && docker inspect --format='{{index .RepoDigests 0}}' node:24-trixie
+FROM node:24-trixie@sha256:135dc9a66aef366e09958c18dab705081d77fb31eccffe8c3865fac9d3e42a1d
 
 ARG TZ
 ENV TZ="$TZ"


### PR DESCRIPTION
Bookworm (glibc 2.36) では rtk arm64 バイナリ (GLIBC_2.39 必須) が実行できなかったため、 Debian 13 (Trixie, glibc 2.41) ベースに切り替え。
amd64 は musl 静的ビルドなので元から影響無し、arm64 のみが恩恵を受ける。
apt パッケージ名は Layer 1〜3 とも Trixie で同名のまま利用可能 (libasound2 / libcups2 / libdbus-1-3 / libsecret-1-dev いずれも present)。
SHA256 digest はローカルで docker pull → docker inspect で取得した値。