### PR TITLE
feat(litellm): Ollama モデル 3 件を LiteLLM Proxy に追加 (finance-llm Phase5)

### DIFF
--- a/litellm/config.yaml
+++ b/litellm/config.yaml
@@ -21,6 +21,31 @@ model_list:
       model: anthropic/claude-opus-4-6
       api_key: os.environ/ANTHROPIC_API_KEY
 
+  # ========== Ollama (host 側で稼働、host.docker.internal 経由) ==========
+  # finance-llm Phase 5: LoRA fine-tuned モデルと比較用ベースを公開
+  # extra_body.think=false は Qwen3 thinking モード暴走防止 (Phase 4 知見)
+  - model_name: qwen3-finance
+    litellm_params:
+      model: ollama_chat/qwen3-finance:v1
+      api_base: http://host.docker.internal:11434
+      extra_body:
+        think: false
+
+  - model_name: qwen3-base
+    litellm_params:
+      model: ollama_chat/qwen3:8b
+      api_base: http://host.docker.internal:11434
+      extra_body:
+        think: false
+
+  # Phase 7 用エイリアス: Claude Code から qwen3-finance を呼ぶ際に anthropic 名で受ける
+  - model_name: claude-3-5-sonnet-20241022
+    litellm_params:
+      model: ollama_chat/qwen3-finance:v1
+      api_base: http://host.docker.internal:11434
+      extra_body:
+        think: false
+
 
 litellm_settings:
   drop_params: true


### PR DESCRIPTION
## Summary
- `litellm/config.yaml` に Ollama 3 モデルを追加 (`qwen3-finance` / `qwen3-base` / `claude-3-5-sonnet-20241022` エイリアス)
- `ollama_chat/...` プレフィックス + `extra_body.think=false` で Qwen3 thinking モード暴走を防止 (Phase 4 知見)
- 接続先は `http://host.docker.internal:11434` (LiteLLM コンテナ → ホスト Ollama)
- Langfuse callback は **追加しない** (評価 trace は別途 finance-llm 側 SDK で投入する設計)

## なぜこの変更が必要か
finance-llm リポで Phase 4 まで完了した LoRA fine-tuned Ollama モデル (`qwen3-finance:v1`) を、Phase 6 (Datasets/Experiment 評価) と Phase 7 (Claude Code 連携) の前段として OpenAI 互換 API で公開するため。LiteLLM はこのリポで既にコンテナ稼働しているので、別途立てずに既存コンテナの config を増やす形で対応。

## Test plan
- [x] `docker compose up -d --build litellm` で再ビルド成功、ログで 7 モデル全部ロード確認
- [x] `/health/liveliness` 200 OK
- [x] host から openai SDK で `qwen3-finance` / `qwen3-base` 呼び出し成功 (両方とも日本語応答返却)
- [x] thinking モード暴走なし (out tokens: qwen3-finance=125 / qwen3-base=265、`max_tokens=400` に張り付かず正常終了)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
